### PR TITLE
Combinations_practical refactor

### DIFF
--- a/examples/Practical_tutorial/Combinations_practical.ipynb
+++ b/examples/Practical_tutorial/Combinations_practical.ipynb
@@ -69,19 +69,19 @@
     "\n",
     "element_assignment = 0\n",
     "\n",
-    "print('number of possible element assignments is: ', float(element_assignment))\n",
+    "print(f'Number of possible element assignments is: {element_assignment}')\n",
     "\n",
     "# B. Show that the number of possible arrangements of 30 atoms on a grid of 10x10x10 is ~2e57 (combinations)\n",
     "\n",
     "atom_arrangements = 0\n",
     "\n",
-    "print('number of atom arrangements is: ', float(atom_arrangements))\n",
+    "print(f'Number of atom arrangements is: {atom_arrangements}')\n",
     "\n",
     "# C. Finally, show that the total number of potential \"materials\" is ~ 2e108\n",
     "\n",
     "total_materials = 0\n",
     "\n",
-    "print('total number of \"materials\" is: ', float(total_materials))"
+    "print(f'Total number of \"materials\" is: {total_materials}')"
    ]
   },
   {
@@ -148,9 +148,8 @@
     "        if int(Z) > 0 and int(Z) < max_atomic_number + 1:\n",
     "            list_of_elements.append(symbol)\n",
     "            \n",
-    "print('--- Considering the {0} elements from {1} to {2} ---'.format(len(list_of_elements),\n",
-    "                                                                    list_of_elements[0],\n",
-    "                                                                    list_of_elements[-1]))"
+    "print(f'--- Considering the {len(list_of_elements)} elements '\n",
+    "      f'from {list_of_elements[0]} to {list_of_elements[-1]} ---')"
    ]
   },
   {
@@ -177,11 +176,11 @@
     "element_count = 0\n",
     "for i, ele_a in enumerate(list_of_elements):\n",
     "    for j, ele_b in enumerate(list_of_elements[i+1:]):\n",
-    "        element_count = element_count + 1\n",
-    "        print '{0:2s} {1:2s}'.format(ele_a, ele_b)\n",
+    "        element_count += 1\n",
+    "        print(f'{ele_a} {ele_b}')\n",
     "\n",
     "# Prints the total number of combinations found\n",
-    "print('Number of combinations = {0}'.format(str(element_count)))"
+    "print(f'Number of combinations = {element_count}')"
    ]
   },
   {
@@ -211,17 +210,19 @@
     "ion_count = 0\n",
     "for i, ele_a in enumerate(list_of_elements):\n",
     "    for ox_a in smact.Element(ele_a).oxidation_states:\n",
+    "        \n",
     "        for j, ele_b in enumerate(list_of_elements[i+1:]):\n",
     "            for ox_b in smact.Element(ele_b).oxidation_states:\n",
+    "                \n",
     "                for k, ele_c in enumerate(list_of_elements[i+j+2:]):\n",
     "                    for ox_c in smact.Element(ele_c).oxidation_states:\n",
-    "                        ion_count = ion_count + 1\n",
+    "                        ion_count += 1\n",
     "                    \n",
-    "                        print('{0:2s} {1:2d}   {2:2s} {3:2d}   {4:2s} {5:2d}'.format(ele_a, ox_a, ele_b, ox_b, ele_c, ox_c))\n",
+    "                        print(f'{ele_a} {ox_a} \\t {ele_b} {ox_b} \\t {ele_c} {ox_c}')\n",
     "\n",
     "# Prints the total number of combinations found and the time taken to run.\n",
-    "print('Number of combinations = {0}'.format(ion_count))\n",
-    "print(\"--- {0} seconds to run ---\".format((time.time() - start_time)))"
+    "print(f'Number of combinations = {ion_count}')\n",
+    "print(f'--- {time.time() - start_time} seconds to run ---')"
    ]
   },
   {
@@ -261,19 +262,21 @@
     "charge_neutral_count = 0\n",
     "for i, ele_a in enumerate(list_of_elements):\n",
     "    for ox_a in smact.Element(ele_a).oxidation_states:\n",
+    "        \n",
     "        for j, ele_b in enumerate(list_of_elements[i+1:]):\n",
     "            for ox_b in smact.Element(ele_b).oxidation_states:\n",
+    "                \n",
     "                for k, ele_c in enumerate(list_of_elements[i+j+2:]):\n",
     "                    for ox_c in smact.Element(ele_c).oxidation_states:\n",
     "                        \n",
     "                        # Checks if the combination is charge neutral before printing it out! #                        \n",
     "                        cn_e, cn_r = neutral_ratios([ox_a, ox_b, ox_c], threshold=1)\n",
     "                        if cn_e:\n",
-    "                            charge_neutral_count = charge_neutral_count + 1\n",
-    "                            print('{0:3s}  {1:3s}  {2:3s}'.format(ele_a, ele_b, ele_c))\n",
+    "                            charge_neutral_count += 1\n",
+    "                            print(f'{ele_a} \\t {ele_b} \\t {ele_c}')\n",
     "\n",
-    "print('Number of combinations = {0}'.format(charge_neutral_count))\n",
-    "print(\"--- {0} seconds to run ---\".format(time.time() - start_time))                      "
+    "print(f'Number of combinations = {charge_neutral_count}')\n",
+    "print(f'--- {time.time() - start_time} seconds to run ---')"
    ]
   },
   {
@@ -307,9 +310,11 @@
     "for i, ele_a in enumerate(list_of_elements):\n",
     "    paul_a = smact.Element(ele_a).pauling_eneg\n",
     "    for ox_a in smact.Element(ele_a).oxidation_states:\n",
+    "        \n",
     "        for j, ele_b in enumerate(list_of_elements[i+1:]):\n",
     "            paul_b = smact.Element(ele_b).pauling_eneg\n",
     "            for ox_b in smact.Element(ele_b).oxidation_states:\n",
+    "                \n",
     "                for k, ele_c in enumerate(list_of_elements[i+j+2:]):\n",
     "                    paul_c = smact.Element(ele_c).pauling_eneg\n",
     "                    for ox_c in smact.Element(ele_c).oxidation_states:\n",
@@ -324,12 +329,11 @@
     "                        cn_e, cn_r = smact.neutral_ratios([ox_a, ox_b, ox_c], threshold=1)\n",
     "                        if cn_e:\n",
     "                            if electroneg_makes_sense:\n",
-    "                                pauling_count = pauling_count + 1\n",
-    "                                print('{0:2s}{1:3d}   {2:2s}{3:3d}   {4:2s}{5:3d}'.format(ele_a, ox_a, ele_b,\n",
-    "                                                                                          ox_b, ele_c, ox_c))\n",
+    "                                pauling_count += 1\n",
+    "                                print(f'{ele_a}{ox_a} \\t {ele_b}{ox_b} \\t {ele_c}{ox_c}')\n",
     "                                \n",
-    "print('Number of combinations = {0}'.format(pauling_count))\n",
-    "print(\"--- {0} seconds to run ---\".format(time.time() - start_time))"
+    "print(f'Number of combinations = {pauling_count}')\n",
+    "print(f'--- {time.time() - start_time} seconds to run ---')"
    ]
   },
   {
@@ -378,7 +382,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/examples/Practical_tutorial/Combinations_practical.ipynb
+++ b/examples/Practical_tutorial/Combinations_practical.ipynb
@@ -325,7 +325,7 @@
     "                        pauling_electro = [paul_a, paul_b, paul_c]\n",
     "                        \n",
     "                        # Checks if the electronegativity makes sense and if the combination is charge neutral #\n",
-    "                        electroneg_makes_sense = pauling_test(elements,oxidation_states, pauling_electro)\n",
+    "                        electroneg_makes_sense = pauling_test(oxidation_states, pauling_electro, elements)\n",
     "                        cn_e, cn_r = smact.neutral_ratios([ox_a, ox_b, ox_c], threshold=1)\n",
     "                        if cn_e:\n",
     "                            if electroneg_makes_sense:\n",


### PR DESCRIPTION
Refactoring of the Combinations_practical notebook, such as converting `.format()` to f-strings and replacing assignments with `+=` where appropriate. Also added in a missing pair of parentheses to a `print` function and fixed the arguments to a call to `pauling_test()`, which were previously in the wrong order.