### PR TITLE
Fixing the method for finding stoichiometries

### DIFF
--- a/smact/structure_prediction/structure.py
+++ b/smact/structure_prediction/structure.py
@@ -19,10 +19,6 @@ import smact
 from . import logger
 from .utilities import get_sign
 
-def find_gcd(list):
-    x = reduce(gcd, list)
-    return x
-
 class SmactStructure:
     """SMACT implementation inspired by pymatgen Structure class.
 
@@ -194,7 +190,7 @@ class SmactStructure:
 
         # Find stoichiometry
         total_specs = [len(val) for val in sites.values()]
-        hcf = find_gcd(total_specs)
+        hcf = reduce(gcd, total_specs)
         total_specs = [int(x / hcf) for x in total_specs]
 
         species = []
@@ -322,7 +318,7 @@ class SmactStructure:
 
         # Find stoichiometry
         total_specs = [int(x) for x in lines[6].split(" ")]
-        hcf=find_gcd(total_specs)
+        hcf = reduce(gcd, total_specs)
         total_specs = [int(x / hcf) for x in total_specs]
 
         species = []

--- a/smact/structure_prediction/structure.py
+++ b/smact/structure_prediction/structure.py
@@ -6,6 +6,9 @@ from collections import defaultdict
 from operator import itemgetter
 from typing import Dict, List, Optional, Tuple, Union
 
+from math import gcd
+from functools import reduce
+
 import numpy as np
 import pymatgen
 from pymatgen.analysis.bond_valence import BVAnalyzer
@@ -16,6 +19,9 @@ import smact
 from . import logger
 from .utilities import get_sign
 
+def find_gcd(list):
+    x = reduce(gcd, list)
+    return x
 
 class SmactStructure:
     """SMACT implementation inspired by pymatgen Structure class.
@@ -188,10 +194,8 @@ class SmactStructure:
 
         # Find stoichiometry
         total_specs = [len(val) for val in sites.values()]
-        total_spec_sum = sum(total_specs)
-        total_specs = [x / total_spec_sum for x in total_specs]
-        total_spec_min = min(total_specs)
-        total_specs = [round(x / total_spec_min) for x in total_specs]
+        hcf = find_gcd(total_specs)
+        total_specs = [int(x / hcf) for x in total_specs]
 
         species = []
         for spec, stoic in zip(sites.keys(), total_specs):
@@ -318,10 +322,8 @@ class SmactStructure:
 
         # Find stoichiometry
         total_specs = [int(x) for x in lines[6].split(" ")]
-        total_spec_sum = sum(total_specs)
-        total_specs = [x / total_spec_sum for x in total_specs]
-        total_spec_min = min(total_specs)
-        total_specs = [round(x / total_spec_min) for x in total_specs]
+        hcf=find_gcd(total_specs)
+        total_specs = [int(x / hcf) for x in total_specs]
 
         species = []
         for spec_str, stoic in zip(lines[0].split(" "), total_specs):


### PR DESCRIPTION
The highest common factor (hcf) is used to find the simplest stoichiometric ratio of species

A bit unsure on the correct syntax to include the find_gcd function within the code though, but this implementation works perfect