### PR TITLE
V2.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 __author__ = "Daniel W. Davies"
 __copyright__ = "Copyright Daniel W. Davies, Adam J. Jackson, Keith T. Butler (2019)"
-__version__ = "2.2"
+__version__ = "2.2.1"
 __maintainer__ = "Daniel W. Davies"
 __email__ = "d.davies16@imperial.ac.uk"
 __date__ = "Jun 10 2019"

--- a/setup.py
+++ b/setup.py
@@ -15,27 +15,41 @@ module_dir = os.path.dirname(os.path.abspath(__file__))
 
 if __name__ == "__main__":
     setup(
-      name='SMACT',
-      version='2.2',
-      description='Semiconducting Materials by Analogy and Chemical Theory',
-      long_description=open(os.path.join(module_dir, 'README.md')).read(),
-      long_description_content_type='text/markdown',
-      url='https://github.com/WMD-group/SMACT',
-      author='Daniel W. Davies',
-      author_email='d.davies16@imperial.ac.uk',
-      license='MIT',
-      packages=['smact', 'smact.tests', 'smact.structure_prediction'],
-      package_data={
-        'smact': ['data/*.txt', 'data/*.csv', 'data/*.data', 'data/*.xlsx', 'data/*.json']
-      },
-      zip_safe=False,
-      test_suite='smact.tests.test',
-      install_requires=['scipy', 'numpy', 'spglib', 'pymatgen', 'ase', 'pandas', 'pathos'],
-      classifiers=[
-        'Programming Language :: Python',
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Science/Research',
-        'Operating System :: OS Independent',
-        'Topic :: Scientific/Engineering'
-      ]
+        name="SMACT",
+        version="2.2.1",
+        description="Semiconducting Materials by Analogy and Chemical Theory",
+        long_description=open(os.path.join(module_dir, "README.md")).read(),
+        long_description_content_type="text/markdown",
+        url="https://github.com/WMD-group/SMACT",
+        author="Daniel W. Davies",
+        author_email="d.davies16@imperial.ac.uk",
+        license="MIT",
+        packages=["smact", "smact.tests", "smact.structure_prediction"],
+        package_data={
+            "smact": [
+                "data/*.txt",
+                "data/*.csv",
+                "data/*.data",
+                "data/*.xlsx",
+                "data/*.json",
+            ]
+        },
+        zip_safe=False,
+        test_suite="smact.tests.test",
+        install_requires=[
+            "scipy",
+            "numpy",
+            "spglib",
+            "pymatgen",
+            "ase",
+            "pandas",
+            "pathos",
+        ],
+        classifiers=[
+            "Programming Language :: Python",
+            "Development Status :: 5 - Production/Stable",
+            "Intended Audience :: Science/Research",
+            "Operating System :: OS Independent",
+            "Topic :: Scientific/Engineering",
+        ],
     )


### PR DESCRIPTION
Add `smact.structure_prediction` to `package_data` in `setup.py` so the module is importable when downloaded from PyPi.