### PR TITLE
Switchable oxidation states

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 __author__ = "Daniel W. Davies"
 __copyright__ = "Copyright Daniel W. Davies, Adam J. Jackson, Keith T. Butler (2019)"
-__version__ = "2.3.1"
+__version__ = "2.3.2"
 __maintainer__ = "Anthony O. Onwuli"
 __email__ = "anthony.onwuli16@imperial.ac.uk"
 __date__ = "Nov 4 2021"
@@ -16,13 +16,15 @@ module_dir = os.path.dirname(os.path.abspath(__file__))
 if __name__ == "__main__":
     setup(
         name="SMACT",
-        version="2.3.1",
+        version="2.3.2",
         description="Semiconducting Materials by Analogy and Chemical Theory",
         long_description=open(os.path.join(module_dir, "README.md")).read(),
         long_description_content_type="text/markdown",
         url="https://github.com/WMD-group/SMACT",
         author="Daniel W. Davies",
         author_email="d.davies16@imperial.ac.uk",
+        maintainer="Anthony O. Onwuli",
+        maintainer_email="anthony.onwuli16@imperial.ac.uk",
         license="MIT",
         packages=["smact", "smact.tests", "smact.structure_prediction"],
         package_data={

--- a/smact/screening.py
+++ b/smact/screening.py
@@ -271,7 +271,7 @@ def ml_rep_generator(composition, stoichs=None):
     norm = [float(i)/sum(ML_rep) for i in ML_rep]
     return norm
 
-def smact_filter(els, threshold=8, species_unique=True):
+def smact_filter(els, threshold=8, species_unique=True, oxidation_states_set='default'):
     """Function that applies the charge neutrality and electronegativity
     tests in one go for simple application in external scripts that
     wish to apply the general 'smact test'.
@@ -281,17 +281,30 @@ def smact_filter(els, threshold=8, species_unique=True):
         threshold (int): Threshold for stoichiometry limit, default = 8
         species_unique (bool): Whether or not to consider elements in different
         oxidation states as unique in the results.
+        oxidation_states_set (string): A string to choose which set of oxidation
+        states should be chosen
     Returns:
         allowed_comps (list): Allowed compositions for that chemical system
         in the form [(elements), (oxidation states), (ratios)] if species_unique=True
         or in the form [(elements), (ratios)] if species_unique=False.
     """
+    
     compositions = []
 
     # Get symbols and electronegativities
     symbols = tuple(e.symbol for e in els)
     electronegs = [e.pauling_eneg for e in els]
-    ox_combos = [e.oxidation_states for e in els]
+
+    # Select the specified oxidation states set:
+    oxi_set = {
+        'default':[e.oxidation_states for e in els],
+        'icsd':[e.oxidation_states_icsd for e in els],
+        'pymatgen': [e.oxidation_states_sp for e in els]
+        }
+    if oxidation_states_set in oxi_set:
+        ox_combos = oxi_set[oxidation_states_set]
+    else:
+        raise(Exception(f'{oxidation_states_set} is not valid. Enter either "default", "icsd" or "pymatgen" for oxidation_states_set.'))
     for ox_states in itertools.product(*ox_combos):
         # Test for charge balance
         cn_e, cn_r = neutral_ratios(ox_states, threshold=threshold)


### PR DESCRIPTION
- Updated setup.py

- Added the option to select the oxidation states in screening.smact_filter. 
- Options are:
   - 'default' for the smart default oxidation states
   - 'icsd' for the oxidation states which appear in the ICSD
   - 'pymatgen' for the oxidation states which are recognise by the Pymatgen Structure Predictor

Resolving issue #48 