### PR TITLE
Oxidation states model example updates

### DIFF
--- a/examples/Oxidation_states/oxidation_states.ipynb
+++ b/examples/Oxidation_states/oxidation_states.ipynb
@@ -1,0 +1,436 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Oxidation states\n",
+    "Here, we will demonstrate the main functionalities of the `oxidation_states` submodule of SMACT.\n",
+    "\n",
+    "TO-DO\n",
+    "* Modify composition generation by SMACT to reproduce exact results from the paper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports\n",
+    "import smact\n",
+    "from smact import Species, Element, screening\n",
+    "from smact.oxidation_states import Oxidation_state_probability_finder\n",
+    "from itertools import combinations, product\n",
+    "import multiprocess"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Instantiate the oxidation state probability finder class with the default table\n",
+    "ox_prob_finder = Oxidation_state_probability_finder()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After instantiating the class, we can examine what species are included in the probability table through the `get_included_species` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Te-2', 'Se-2', 'Br-1', 'O-2', 'S-2', 'F-1', 'Cl-1', 'I-1', 'V5', 'Bi1', 'Hg2', 'Eu2', 'Ta1', 'Zr1', 'Pb2', 'Th4', 'Cr4', 'Ti2', 'Be2', 'Sb4', 'Re5', 'Sb3', 'Mo6', 'Ni3', 'Ga2', 'Nd3', 'Ni1', 'Cr6', 'Mn6', 'In3', 'V3', 'La3', 'W3', 'Ho2', 'Ta4', 'Cu1', 'W5', 'Cr3', 'Fe1', 'Re6', 'Rb1', 'Sm3', 'Pd2', 'Ce3', 'Sc2', 'Cr5', 'Tm3', 'W4', 'Pr3', 'Mo2', 'Ag3', 'Ir3', 'Li1', 'Cs1', 'Mn4', 'Al3', 'V4', 'Mn1', 'Rh1', 'Ru5', 'La1', 'Bi5', 'Cd2', 'Ce2', 'Yb3', 'Ru2', 'Ru3', 'Cr2', 'Co3', 'Na1', 'Ru4', 'Ag1', 'Zn2', 'Pb4', 'Mn2', 'Ir6', 'Ta3', 'Tb1', 'K1', 'Ti4', 'Rh3', 'Nb1', 'Ti3', 'Sr2', 'Y3', 'Gd3', 'Ta2', 'Zr2', 'Gd2', 'Th3', 'Lu3', 'Tm2', 'Sn3', 'Ca2', 'Nb3', 'Re3', 'Cu2', 'Er3', 'Bi3', 'V2', 'Fe2', 'Sb5', 'Mg2', 'Ce4', 'Ta5', 'U6', 'Nb2', 'Ag2', 'Re4', 'Yb2', 'In2', 'Ga1', 'Tb3', 'Mn7', 'La2', 'Tl1', 'Bi2', 'Mn3', 'Ho3', 'Rh4', 'Tl3', 'U2', 'Fe4', 'Ge2', 'Mo3', 'Pr2', 'U3', 'W6', 'Ni4', 'Fe3', 'Ga3', 'Ba2', 'In1', 'Re2', 'Sn4', 'Ir4', 'Sn2', 'U4', 'U5', 'Zr3', 'Nb4', 'Zr4', 'Eu3', 'Pd4', 'Y1', 'Hf4', 'Nd2', 'Y2', 'W2', 'Re7', 'Ni2', 'Co1', 'Tb2', 'Dy2', 'Hf2', 'Tb4', 'Mn5', 'Cu3', 'Ir5', 'Sc3', 'Mo4', 'Dy3', 'Co4', 'Ge3', 'Sm2', 'Hg1', 'Nb5', 'Ru6', 'Ge4', 'Sc1', 'Pd3', 'Co2', 'Mo5']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(ox_prob_finder.get_included_species())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can compute the probability of a cation-anion pair appearing together using the method `pair_probability` as demonstrated below for Al<sup>3+</sup> and O<sup>2-</sup>."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Al=Species('Al', oxidation = 3, coordination=6)\n",
+    "O=Species('O', oxidation=-2, coordination=6)\n",
+    "ox_prob_finder.pair_probability(Al,O)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's reproduce the results from the publication.\n",
+    "First we will generate the input compositions from the paper."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the elements\n",
+    "\n",
+    "all_el = smact.element_dictionary()\n",
+    "symbol_list = [k for k,i in all_el.items()]\n",
+    "\n",
+    "d_block_symbols = smact.ordered_elements(21,30) + smact.ordered_elements(39,48) + smact.ordered_elements(71,80)\n",
+    "\n",
+    "d_block_elements = [all_el[x] for x in symbol_list if x in d_block_symbols]\n",
+    "\n",
+    "d_block_combos = combinations(d_block_elements,2)\n",
+    "\n",
+    "def smact_filter(els):\n",
+    "    all_compounds = []\n",
+    "    halide_symbols = ['F','Cl','Br','I']\n",
+    "\n",
+    "    for halide in halide_symbols:\n",
+    "        elements = [e.symbol for e in els] +[halide]\n",
+    "\n",
+    "        # Get the Pauling electronegativities\n",
+    "        paul_a, paul_b, paul_x = els[0].pauling_eneg, els[1].pauling_eneg, Element(halide).pauling_eneg\n",
+    "        electronegativities = [paul_a, paul_b, paul_x]\n",
+    "    \n",
+    "        # For each set of species (in oxidation states) apply both SMACT tests\n",
+    "        for ox_a, ox_b in product(els[0].oxidation_states, \n",
+    "                        els[1].oxidation_states):      \n",
+    "            ox_states = [ox_a, ox_b, -1]\n",
+    "            # Test for charge balance\n",
+    "            cn_e, cn_r = smact.neutral_ratios(ox_states, threshold = 8)\n",
+    "            if cn_e:\n",
+    "                # Electronegativity test\n",
+    "                electroneg_OK = screening.pauling_test(ox_states, electronegativities)\n",
+    "                if electroneg_OK:\n",
+    "                    compound = tuple([elements,(ox_a,ox_b,-1),cn_r[0]])\n",
+    "                    all_compounds.append(compound)\n",
+    "    return all_compounds\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of compositions: 38788\n",
+      "Each list entry looks like this:\n",
+      "  elements, oxidation states, stoichiometries\n",
+      "(['Sc', 'Ti', 'F'], (1, -1, -1), (2, 1, 1))\n",
+      "(['Sc', 'Ti', 'F'], (1, 1, -1), (1, 1, 2))\n",
+      "(['Sc', 'Ti', 'F'], (1, 2, -1), (1, 1, 3))\n",
+      "(['Sc', 'Ti', 'F'], (1, 3, -1), (1, 1, 4))\n",
+      "(['Sc', 'Ti', 'F'], (1, 4, -1), (1, 1, 5))\n"
+     ]
+    }
+   ],
+   "source": [
+    "with multiprocess.Pool(3) as p:\n",
+    "    result = p.map(smact_filter, d_block_combos)\n",
+    "    \n",
+    "flat_list = [item for sublist in result for item in sublist]\n",
+    "print(\"Number of compositions: {0}\".format(len(flat_list)))\n",
+    "print('Each list entry looks like this:\\n  elements, oxidation states, stoichiometries')\n",
+    "for i in flat_list[:5]:\n",
+    "    print(i)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Each list entry now looks like this: \n",
+      "Sc2TiF\n",
+      "ScTiF2\n",
+      "ScTiF3\n",
+      "ScTiF4\n",
+      "ScTiF5\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pymatgen.core import Composition\n",
+    "def comp_maker(comp):\n",
+    "    form = []\n",
+    "    for el, ammt in zip(comp[0], comp[2]):\n",
+    "        form.append(el)\n",
+    "        form.append(ammt)\n",
+    "    form = ''.join(str(e) for e in form)\n",
+    "    pmg_form = Composition(form).reduced_formula\n",
+    "    return pmg_form\n",
+    "\n",
+    "if __name__ == '__main__':  \n",
+    "    with multiprocess.Pool(3) as p:\n",
+    "        pretty_formulas = p.map(comp_maker, flat_list)\n",
+    "\n",
+    "print('Each list entry now looks like this: ')\n",
+    "for i in pretty_formulas[:5]:\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below, we convert our list of elements, oxidation_states, stoichiometries into a list of lists of `smact.Species`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "def species_maker(comp):\n",
+    "    species_list=[]\n",
+    "    for el, ox in zip(comp[0], comp[1]):\n",
+    "        species_list.append(Species(el,oxidation=ox))\n",
+    "    return species_list\n",
+    "if __name__ == '__main__':  \n",
+    "    with multiprocess.Pool(3) as p:\n",
+    "        list_of_species = p.map(species_maker, flat_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The method `compound_probability` of the `Oxidation_state_probability_finder` class enables us to compute the likelihood of the metal species existing in the presence of particular anions. We will apply this to all the compounds generated by `smact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def compute_compound_probability(species_list):\n",
+    "    try:\n",
+    "       return ox_prob_finder.compound_probability(species_list)\n",
+    "    except NameError:\n",
+    "        return None\n",
+    "\n",
+    "# Compute the compound probabilities \n",
+    "compound_probabilities = [compute_compound_probability(spec) for spec in list_of_species]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>formula_pretty</th>\n",
+       "      <th>prob</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Sc2TiF</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>ScTiF2</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>ScTiF3</td>\n",
+       "      <td>0.019608</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>ScTiF4</td>\n",
+       "      <td>0.176471</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>ScTiF5</td>\n",
+       "      <td>0.303922</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  formula_pretty      prob\n",
+       "0         Sc2TiF  0.000000\n",
+       "1         ScTiF2       NaN\n",
+       "2         ScTiF3  0.019608\n",
+       "3         ScTiF4  0.176471\n",
+       "4         ScTiF5  0.303922"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create a dataframe\n",
+    "data = {'formula_pretty':pretty_formulas, 'prob': compound_probabilities}\n",
+    "\n",
+    "df = pd.DataFrame(data)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Our original smact query generated 38788 compositions. \n",
+      "We could compute compute compound probabilities for 20360 compositions. \n",
+      "Finally, there are 15884 compositions which have a non-zero compound probability.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get the dataframe without the None probabilities\n",
+    "notNone_df=df.dropna(axis=0).reset_index(drop=True)\n",
+    "\n",
+    "# Get the dataframe with the non-zero probabilities\n",
+    "nonZero_df= notNone_df.loc[notNone_df.prob>0].reset_index(drop=True)\n",
+    "\n",
+    "print(f'Our original smact query generated {len(pretty_formulas)} compositions. \\nWe could compute compute compound probabilities for {notNone_df.shape[0]} compositions. \\nFinally, there are {nonZero_df.shape[0]} compositions which have a non-zero compound probability.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will know plot the number of compounds as a function of the probability threshold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk0AAAGwCAYAAAC0HlECAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy89olMNAAAACXBIWXMAAA9hAAAPYQGoP6dpAABX4klEQVR4nO3de1hU5do/8O8gzAwHZxBSYBLJXdsDHjA1kTy02/FKaZZb24GakuIhD6nga+jPPGS7UEvdWoZamez3rSS36ZuHNPLEVkEUxSOiJnkIAbfIjJxB1u8P96wYh8MaXAwz8P1c11yXs9Yza+61KufuWfe6H4UgCAKIiIiIqFYOjR0AERERkT1g0kREREQkAZMmIiIiIgmYNBERERFJwKSJiIiISAImTUREREQSMGkiIiIiksCxsQNoKiorK5GVlYWWLVtCoVA0djhEREQkgSAIuHfvHnQ6HRwcap9LYtIkk6ysLPj6+jZ2GERERFQPN27cQNu2bWsdw6RJJi1btgTw4KJrNBrZjltUVoE+H+wDAKTMfwEuSv4jIyIikovBYICvr6/4O14b/gLLxHhLTqPRyJo0OZZVwEHlIh6bSRMREZH8pJTWsBCciIiISAImTUREREQSMGkiIiIikoBJExEREZEETJqIiIiIJGDSRERERCQBkyYiIiIiCZg0EREREUnQqElTYmIihg4dCp1OB4VCge3bt5uNSU9PxyuvvAKtVgtXV1c888wzuH79uri/pKQE06ZNg6enJ9zc3DBixAjk5OSYHOP69esYMmQIXFxc0KZNG8yZMwcVFRUmYw4ePIiePXtCpVLhqaeewqZNmxrilImIiMhONWrSVFhYiICAAKxdu7ba/b/88gv69++PTp064eDBgzhz5gwWLFgAtVotjomMjMSOHTuwZcsWHDp0CFlZWRg+fLi4//79+xgyZAjKyspw9OhRxMXFYdOmTVi4cKE4JjMzE0OGDMHzzz+PtLQ0zJo1CxMmTMDevXsb7uTrYCgpxy19cbX7bumLYSgpt3JEREREzZtCEAShsYMAHrQv37ZtG4YNGyZuCwsLg5OTE/7nf/6n2s/o9Xq0bt0a33zzDV577TUAwMWLF9G5c2ckJSWhb9+++PHHH/Hyyy8jKysLXl5eAIB169YhOjoat2/fhlKpRHR0NHbt2oVz586ZfHd+fj727NlT7XeXlpaitLRUfG9cu0av1z/yMiqGknKEb0zBnYIyfPXmM3hh5SEAwIUlIcgvKkfYhmR4uikRN74PNGqnR/ouIiKi5sxgMECr1Ur6/bbZmqbKykrs2rULHTp0QEhICNq0aYPAwECTW3ipqakoLy9HcHCwuK1Tp05o164dkpKSAABJSUno1q2bmDABQEhICAwGA86fPy+OqXoM4xjjMaoTExMDrVYrvnx9feU4bQBAYWkF7hSU4XpeEcK/ShG338ovQdiGZFzPK8KdgjIUllbUchQiIiKSk80mTbm5uSgoKMDSpUvx4osv4qeffsJf/vIXDB8+HIcOPZh5yc7OhlKphLu7u8lnvby8kJ2dLY6pmjAZ9xv31TbGYDCguLj6W2Tz5s2DXq8XXzdu3Hjkczby0Tpj86S+aOfhgpt3f//+8K9ScD2vCO08XLB5Ul/4aJ1l+04iIiKqnWNjB1CTyspKAMCrr76KyMhIAECPHj1w9OhRrFu3Ds8991xjhgeVSgWVStVgx9e5P0icXl+fJCZON+8WiwmTzp0JExERkTXZ7EzTY489BkdHR/j7+5ts79y5s/j0nLe3N8rKypCfn28yJicnB97e3uKYh5+mM76va4xGo4Gzc+MlJzp3Zywb0c1k26rQADFhYrE4ERGR9dhs0qRUKvHMM88gIyPDZPulS5fg5+cHAOjVqxecnJywb98+cX9GRgauX7+OoKAgAEBQUBDOnj2L3NxccUxCQgI0Go2YkAUFBZkcwzjGeIzGkpVfjOitZ022RcafRlZ+sVgsHro+GVn5xWafC12fjPCNKUyciIiIZNKoSVNBQQHS0tKQlpYG4MGj/2lpaeJM0pw5cxAfH4/PP/8cV65cwaeffoodO3Zg6tSpAACtVouIiAhERUXhwIEDSE1Nxbhx4xAUFIS+ffsCAAYNGgR/f3+MGTMGp0+fxt69e/Huu+9i2rRp4u21t956C1evXsU777yDixcv4rPPPsN3330n3hZsDFn5xQjbkGxS09S2lTOu5xUhbEMyruYWiMXiYRt+T5yMn2OxOBERkbwateXAwYMH8fzzz5ttDw8PF5tLbty4ETExMbh58yY6duyI9957D6+++qo4tqSkBLNnz8a3336L0tJShISE4LPPPhNvvQHAtWvXMGXKFBw8eBCurq4IDw/H0qVL4ej4e0nXwYMHERkZiQsXLqBt27ZYsGAB3nzzTcnnYskji3W5pX8wU3Q9rwhtWzmLidO+qOcwbtNxsRh8zcgemPFtmvh+VWgAIuNPmxSLs/aJiIioZpb8fttMnyZ7J2fSZEmfpoKSCnFmyYgJExERkTSW/H7b7NNzzZlG7YS48X1QWFoBrbNp80qduzPiJ/eFq8oRGrUTNGonrAoNwIjY33tKVS0WJyIiInnYbCF4c6dRO9XYh8lH6yx2As/KL0Zk/GmT/cZicSIiIpIPkyY7VrXou52HC7ZOCUI7Dxez4nAiIiJ6dEya7NQtvWnCtHlSX/Ty8xA7iRsTp5r6OBEREZFlmDTZKVeVIzzdlGZF38ZO4u08XODppoSrimVrREREcuAvqp2qWiz+cO1T1WJx4MGsVHX1Ubf0xWJBOREREdWOM012rK5icQDsGk5ERCQTJk1NWGFpBbuGExERyYRJUxPmo3U2KwxPvZZnVkBe02wVERER/Y5JUxNXtTD8el4RRsQmcZkVIiKiemDS1Azo3J2xKjTAZBu7hhMREVmGSVMzwK7hREREj45JUxPHruFERETyYNLUhLFrOBERkXyYNDVh7BpOREQkH/5aNmFSu4azIzgREVHdmDQ1cRq1U41JEfszERERScfbc0REREQSMGkiIiIikoBJE8FQUl7jE3S39MVc0JeIiAhMmpo9Q0k5wjemIHS9ec+mrPxihK5PRvjGFCZORETU7DFpauYKSytwp6DMrNll1aaYdwrKUFha0ciREhERNS4mTc2cj9bZrNll6rU8s6aYfNKOiIiaOyZNZNLs8npeEUbEJpkkTFzYl4iIiEkT/YfO3RmrQgNMtq0KDWDCRERE9B9MmgjAgxqmyPjTJtsi409zQV8iIqL/YNJEJkXf7TxcsHVKkEmNExMnIiIiJk3N3i19sVnRdy8/D7Pi8Jr6OBERETUXTJqaOVeVIzzdlGZF31WLwz3dlHBVcZlCIiJq3vhL2Mxp1E6IG98HhaUVZm0FdO7OiJ/cF64qxxoX/SUiImoumDQRNGqnGpOiqomUoaS82uQKeHCbj8kVERE1ZY16ey4xMRFDhw6FTqeDQqHA9u3baxz71ltvQaFQ4O9//7vJ9ry8PIwePRoajQbu7u6IiIhAQUGByZgzZ85gwIABUKvV8PX1xfLly82Ov2XLFnTq1AlqtRrdunXD7t275TjFJoPLrRARUXPXqElTYWEhAgICsHbt2lrHbdu2DcnJydDpdGb7Ro8ejfPnzyMhIQE7d+5EYmIiJk2aJO43GAwYNGgQ/Pz8kJqaio8++giLFy/Ghg0bxDFHjx7FyJEjERERgVOnTmHYsGEYNmwYzp07J9/J2jkut0JERM2dQhAEobGDAACFQoFt27Zh2LBhJtt/++03BAYGYu/evRgyZAhmzZqFWbNmAQDS09Ph7++P48ePo3fv3gCAPXv2YPDgwbh58yZ0Oh1iY2Mxf/58ZGdnQ6lUAgDmzp2L7du34+LFiwCA0NBQFBYWYufOneL39u3bFz169MC6deskxW8wGKDVaqHX66HRaB7xavyuqKwC/gv3AgAuLAmBi7Lx7qg+3JpgVWgAIuNPs3s4ERHZLUt+v2366bnKykqMGTMGc+bMQZcuXcz2JyUlwd3dXUyYACA4OBgODg44duyYOGbgwIFiwgQAISEhyMjIwN27d8UxwcHBJscOCQlBUlJSjbGVlpbCYDCYvJo6LrdCRETNmU0nTcuWLYOjoyNmzJhR7f7s7Gy0adPGZJujoyM8PDyQnZ0tjvHy8jIZY3xf1xjj/urExMRAq9WKL19fX8tOzk5xuRUiImqubDZpSk1NxerVq7Fp0yYoFIrGDsfMvHnzoNfrxdeNGzcaOySr4HIrRETUXNls0vSvf/0Lubm5aNeuHRwdHeHo6Ihr165h9uzZeOKJJwAA3t7eyM3NNflcRUUF8vLy4O3tLY7JyckxGWN8X9cY4/7qqFQqaDQak1dTx+VWiIioObPZpGnMmDE4c+YM0tLSxJdOp8OcOXOwd++DwuigoCDk5+cjNTVV/Nz+/ftRWVmJwMBAcUxiYiLKy39/FD4hIQEdO3ZEq1atxDH79u0z+f6EhAQEBQU19GnaDS63QkREzV2jNrcsKCjAlStXxPeZmZlIS0uDh4cH2rVrB09PT5PxTk5O8Pb2RseOHQEAnTt3xosvvoiJEydi3bp1KC8vx/Tp0xEWFia2Jxg1ahTee+89REREIDo6GufOncPq1auxatUq8bgzZ87Ec889hxUrVmDIkCHYvHkzTpw4YdKWoLkzLrcCoNrlVsI2JHO5FSIiatqERnTgwAEBgNkrPDy82vF+fn7CqlWrTLbduXNHGDlypODm5iZoNBph3Lhxwr1790zGnD59Wujfv7+gUqmExx9/XFi6dKnZsb/77juhQ4cOglKpFLp06SLs2rXLonPR6/UCAEGv11v0uboUlpYLftE7Bb/onUJhabmsx7aUvrhMyMovqnZfVn6RoC8us3JEREREj8aS32+b6dNk75pDnyYiIqKmpsn0aSIiIiKyFUyaiIiIiCRg0kREREQkAZMmIiIiIgmYNBERERFJwKSJiIiISAImTSQrQ0l5jV3Bb+mLYSgpr3YfERGRrWPSRLIxlJQjfGMKQtebr0OXlV+M0PXJCN+YwsSJiIjsEpMmkk1haQXuFJSZLeBbdaHfOwVlKCytaORIiYiILMekiWTjo3U2W8A39Vqe2UK/Plrnxg6ViIjIYkyaSFbGBXyNidOI2CSThMm40C8REZG9YdJEstO5O2NVaIDJtlWhAUyYiIjIrjFpItll5RcjMv60ybbI+NNmxeFERET2hEkTyapq0Xc7DxdsnRJkUuPExImIiOwVkyaSzS19sVnRdy8/D7Pi8Jr6OBEREdkyJk0kG1eVIzzdlGZF31WLwz3dlHBVOTZypERERJbjrxfJRqN2Qtz4PigsrTBrK6Bzd0b85L5wVTlCo3ZqpAiJiIjqj0kTyUqjdqoxKWJ/JiIisme8PUdEREQkAZMmIiIiIgmYNJHVGUrKa3yC7pa+mAv6EhGRTWLSRFZlKClH+MYUhK4379mUlV+M0PXJCN+YwsSJiIhsDpMmsqrC0grcKSgza3ZZtSnmnYIyFJZWNHKkREREppg0kVX5aJ3Nml2mXssza4rJJ+2IiMjWMGkiq6va7PJ6XhFGxCaZJExc2JeIiGwRkyZqFDp3Z6wKDTDZtio0gAkTERHZLCZN1Ciy8osRGX/aZFtk/Gku6EtERDaLSRNZXdWi73YeLtg6JcikxomJExER2SImTWRVt/TFZkXfvfw8zIrDa+rjRERE1FiYNJFVuaoc4emmNCv6rloc7ummhKuKyyISEZFt4S8TWZVG7YS48X1QWFph1lZA5+6M+Ml94apyrHHRXyIiosbSqDNNiYmJGDp0KHQ6HRQKBbZv3y7uKy8vR3R0NLp16wZXV1fodDqMHTsWWVlZJsfIy8vD6NGjodFo4O7ujoiICBQUFJiMOXPmDAYMGAC1Wg1fX18sX77cLJYtW7agU6dOUKvV6NatG3bv3t0g50wPEqea+jD5aJ2ZMBERkU1q1KSpsLAQAQEBWLt2rdm+oqIinDx5EgsWLMDJkyfx/fffIyMjA6+88orJuNGjR+P8+fNISEjAzp07kZiYiEmTJon7DQYDBg0aBD8/P6SmpuKjjz7C4sWLsWHDBnHM0aNHMXLkSERERODUqVMYNmwYhg0bhnPnzjXcyRMREZFdUQiCIDR2EACgUCiwbds2DBs2rMYxx48fR58+fXDt2jW0a9cO6enp8Pf3x/Hjx9G7d28AwJ49ezB48GDcvHkTOp0OsbGxmD9/PrKzs6FUKgEAc+fOxfbt23Hx4kUAQGhoKAoLC7Fz507xu/r27YsePXpg3bp1kuI3GAzQarXQ6/XQaDT1vArmisoq4L9wLwDgwpIQuCibxx1VQ0l5tbfwgAfF5LyFR0REcrDk99uuCsH1ej0UCgXc3d0BAElJSXB3dxcTJgAIDg6Gg4MDjh07Jo4ZOHCgmDABQEhICDIyMnD37l1xTHBwsMl3hYSEICkpqcZYSktLYTAYTF4kDy7qS0REtshukqaSkhJER0dj5MiRYiaYnZ2NNm3amIxzdHSEh4cHsrOzxTFeXl4mY4zv6xpj3F+dmJgYaLVa8eXr6/toJ0giLupLRES2yC6SpvLycrz++usQBAGxsbGNHQ4AYN68edDr9eLrxo0bjR1Sk8FFfYmIyBbZfIGMMWG6du0a9u/fb3K/0dvbG7m5uSbjKyoqkJeXB29vb3FMTk6OyRjj+7rGGPdXR6VSQaVS1f/EqFbGvk3GRGlE7INbpVzUl4iIGotNzzQZE6bLly/j559/hqenp8n+oKAg5OfnIzU1Vdy2f/9+VFZWIjAwUByTmJiI8vLf618SEhLQsWNHtGrVShyzb98+k2MnJCQgKCiooU6NJOCivkREZEsaNWkqKChAWloa0tLSAACZmZlIS0vD9evXUV5ejtdeew0nTpzA119/jfv37yM7OxvZ2dkoKysDAHTu3BkvvvgiJk6ciJSUFBw5cgTTp09HWFgYdDodAGDUqFFQKpWIiIjA+fPnER8fj9WrVyMqKkqMY+bMmdizZw9WrFiBixcvYvHixThx4gSmT59u9WtCv+OivkREZFOERnTgwAEBgNkrPDxcyMzMrHYfAOHAgQPiMe7cuSOMHDlScHNzEzQajTBu3Djh3r17Jt9z+vRpoX///oJKpRIef/xxYenSpWaxfPfdd0KHDh0EpVIpdOnSRdi1a5dF56LX6wUAgl6vr9e1qElhabngF71T8IveKRSWlst6bFv2290iYcCy/YJf9E5hwLL9wolf75i8/+1uUWOHSERETYAlv98206fJ3rFPk3xu6R+0Faha9K1zdzZ5eq6dhwviJ7MYnIiIHk2T7dNEzYPURX0rBQG39NXfqrulL2YfJyIiklXTn7YguyNlUd9KQcD0b07hTkGZ2dN0xhkpTzcl4sb3YedwIiKShcUzTXv27MHhw4fF92vXrkWPHj0watQoscM20aOqa1FfB4WCDTCJiMiqLE6a5syZIy4ZcvbsWcyePRuDBw9GZmamyRNpRA2JDTCJiMjaLL49l5mZCX9/fwDA1q1b8fLLL+PDDz/EyZMnMXjwYNkDJKoJG2ASEZE1WTzTpFQqUVRUBAD4+eefMWjQIACAh4cHF60lq2MDTCIishaLk6b+/fsjKioK77//PlJSUjBkyBAAwKVLl9C2bVvZAySqDRtgEhGRtVicNH366adwdHTEP//5T8TGxuLxxx8HAPz444948cUXZQ+QqCYP923aOiXIpMaJiRMREcmJzS1lwuaW1sUGmEREJAdLfr8l/QJbUqskZ8JAVBNjA0wA1TbANPZpclUxySQiInlI+kVxd3eHQqGQdMD79+8/UkBEUkhpgOmqcmRjSyIiko2kpOnAgQPin3/99VfMnTsXb775JoKCggAASUlJiIuLQ0xMTMNESVQNjdqpxqSIt+SIiEhukpKm5557TvzzkiVLsHLlSowcOVLc9sorr6Bbt27YsGEDwsPD5Y+SiIiIqJFZ/PRcUlISevfubba9d+/eSElJkSUoIiIiIltjcdLk6+uLzz//3Gz7F198AV9fX1mCIpKToaQct/TVtx+4pS+GoaTcyhEREZE9svjRolWrVmHEiBH48ccfERgYCABISUnB5cuXsXXrVtkDJHoUhpJyhG9MwZ2CMrOlVYztCTzdlIgb34dF40REVCuLZ5oGDx6My5cvY+jQocjLy0NeXh6GDh2KS5cuce05sjmFpRW4U1Bm1vCyaj+nOwVlKCytaORIiYjI1rG5pUzY3NJ2PdzwclVoACLjT5s1xiQiouZH9uaWD8vPz0dKSgpyc3NRWVlpsm/s2LH1OSRRg6na8PJ6XhFGxCYBABMmIiKyiMVJ044dOzB69GgUFBRAo9GYNL1UKBRMmsgm6dydsSo0QEyYAGBVaAATJiIikszimqbZs2dj/PjxKCgoQH5+Pu7evSu+8vLyGiJGokeWlV+MyPjTJtsi409zUV8iIpLM4qTpt99+w4wZM+Di4tIQ8RDJ7uGapq1TgtDOw8WsOJyIiKg2FidNISEhOHHiREPEQiS7W3rThGnzpL7o5eeBzZP6miROl3PusZcTERHVyuKapiFDhmDOnDm4cOECunXrBicn0942r7zyimzBET0qV5UjPN2UAGBS9F21ONzdxQmzt5xGflE5ezkREVGNLG454OBQ8+SUQqHA/fv3Hzkoe8SWA7bLUFKOwtKKahfxvaUvxr2SCkyIO2HWguDh23rxk/tyIWAioibGkt9vi2/PVVZW1vhqrgkT2TaN2qnGZMdH64wOXi3NbtelXsszu63HhImIqHmzOGkiaoqMt+uMidOI2CQ2vyQiIhMW3+tZsmRJrfsXLlxY72CIGhN7ORERUW0sTpq2bdtm8r68vByZmZlwdHTEk08+yaSJ7FZNvZw400REREA9kqZTp06ZbTMYDHjzzTfxl7/8RZagiKyttvXpwjYkM3EiIiJ5apo0Gg3ee+89LFiwQI7DEVmV1F5ONfVxIiKi5kG2QnC9Xg+9Xi/X4YisxtjL6eGi76rF4Z5uSriq2O6BiKg5szhpWrNmjclr9erVmDt3LkJDQ/HSSy9ZdKzExEQMHToUOp0OCoUC27dvN9kvCAIWLlwIHx8fODs7Izg4GJcvXzYZk5eXh9GjR0Oj0cDd3R0REREoKCgwGXPmzBkMGDAAarUavr6+WL58uVksW7ZsQadOnaBWq9GtWzfs3r3bonMh+6VROyFufB/ETza/Badzd0b85L5sbElERJbXNK1atcrkvYODA1q3bo3w8HDMmzfPomMVFhYiICAA48ePx/Dhw832L1++HGvWrEFcXBzat2+PBQsWICQkBBcuXIBarQYAjB49Grdu3UJCQgLKy8sxbtw4TJo0Cd988w2AB/VWgwYNQnBwMNatW4ezZ89i/PjxcHd3x6RJkwAAR48exciRIxETE4OXX34Z33zzDYYNG4aTJ0+ia9eull4iskMatVONSRH7MxEREQBAsBEAhG3btonvKysrBW9vb+Gjjz4St+Xn5wsqlUr49ttvBUEQhAsXLggAhOPHj4tjfvzxR0GhUAi//fabIAiC8NlnnwmtWrUSSktLxTHR0dFCx44dxfevv/66MGTIEJN4AgMDhcmTJ9cYb0lJiaDX68XXjRs3BACCXq+v3wWoQWFpueAXvVPwi94pFJaWy3pssoy+uEzIyi+qdl9WfpGgLy6zckRERPSo9Hq95N/vR6ppunnzJm7evClH7mYmMzMT2dnZCA4OFrdptVoEBgYiKelBH52kpCS4u7ujd+/e4pjg4GA4ODjg2LFj4piBAwdCqVSKY0JCQpCRkYG7d++KY6p+j3GM8XuqExMTA61WK758fX0f/aTJZhlKyhG+MQWh65ORlW9aEJ6VX4zQ9ckI35jChX2JiJqwei2jsmTJEmi1Wvj5+cHPzw/u7u54//33UVlZKVtg2dnZAAAvLy+T7V5eXuK+7OxstGnTxmS/o6MjPDw8TMZUd4yq31HTGOP+6sybN08sftfr9bhx44alp0h2pLC0AncKysQn6YyJU9VWBXcKylBYWtHIkRIRUUOxuKZp/vz5+PLLL7F06VL069cPAHD48GEsXrwYJSUl+OCDD2QP0hapVCqoVKrGDoOsxEf74Ek6Y4IUtiHZpJcT16cjImr6LE6a4uLi8MUXX+CVV14Rt3Xv3h2PP/44pk6dKlvS5O3tDQDIycmBj4+PuD0nJwc9evQQx+Tm5pp8rqKiAnl5eeLnvb29kZOTYzLG+L6uMcb9RMDvLQiMiZNxuRWuT0dE1DxYfHsuLy8PnTp1MtveqVMn5OXlyRIUALRv3x7e3t7Yt2+fuM1gMODYsWMICgoCAAQFBSE/Px+pqanimP3796OyshKBgYHimMTERJSX/15rkpCQgI4dO6JVq1bimKrfYxxj/B4iI+P6dFVxfToioubB4qQpICAAn376qdn2Tz/9FAEBAdV8omYFBQVIS0tDWloagAfF32lpabh+/ToUCgVmzZqFv/3tb/jhhx9w9uxZjB07FjqdDsOGDQMAdO7cGS+++CImTpyIlJQUHDlyBNOnT0dYWBh0Oh0AYNSoUVAqlYiIiMD58+cRHx+P1atXIyoqSoxj5syZ2LNnD1asWIGLFy9i8eLFOHHiBKZPn27p5aEmrqb16R4uDicioibI0kfzDh48KLi6ugqdO3cWxo8fL4wfP17o3Lmz4ObmJiQmJlp0rAMHDggAzF7h4eGCIDxoO7BgwQLBy8tLUKlUwgsvvCBkZGSYHOPOnTvCyJEjBTc3N0Gj0Qjjxo0T7t27ZzLm9OnTQv/+/QWVSiU8/vjjwtKlS81i+e6774QOHToISqVS6NKli7Br1y6LzsWSRxYtwZYDtuO3u0XCgGX7Bb/oncKAZfuFE7/eMXn/293q2xEQEZHtsuT3WyEIgmBpopWVlYW1a9fi4sWLAB7M+EydOlWc3WmODAYDtFot9Ho9NBqNbMctKquA/8K9AIALS0LgouRSHo3hlv5BW4GqRd86d2ezhX6/DO8NN7VjtQXht/TFcFU5srM4EZENseT3u16/wDqdrtk8JUcE/L4+HYBq16cL25AMdxcnzN5yGvlF5WaF4cbkytNNySVZiIjsVL2Sprt37+LLL79Eeno6AMDf3x/jxo2Dh4eHrMER2Qrj+nSFpRVms0jG9enulVRgQtwJsSVBdbNRwIOeT0yaiIjsj8WF4ImJiXjiiSewZs0a3L17F3fv3sWaNWvQvn17JCYmNkSMRDZBo3aqsQ+Tj9YZHbxaYvOkvmjn4SImTqnX8kxu37GXExGR/bK4pqlbt24ICgpCbGwsWrRoAQC4f/8+pk6diqNHj+Ls2bMNEqitY00TGT08swSwlxMRka2y5Pfb4pmmK1euYPbs2WLCBAAtWrRAVFQUrly5Ynm0RE0MezkRETVNFidNPXv2FGuZqkpPT7e4TxNRU8ReTkRETZPF93pmzJiBmTNn4sqVK+jbty8AIDk5GWvXrsXSpUtx5swZcWz37t3li5TIDjzcgqDq+nRVi8OJiMj+WFzT5OBQ++SUQqGAIAhQKBS4f//+IwVnT1jTRFJ7OcVPZjE4EZGtaNA+TZmZmfUOjKgpk9LLydNNCVcVE18iIntk8d/efn5+DREHkd2T0suJHcGJiOxXvf6XNysrC4cPH0Zubi4qKytN9s2YMUOWwIjskUbtVGNSxFtyRET2zeKkadOmTZg8eTKUSiU8PT2hUCjEfQqFgkkTERERNUkWJ00LFizAwoULMW/evDqLwomIiIiaCouznqKiIoSFhTFhIiIiombF4swnIiICW7ZsaYhYiIiIiGyWxbfnYmJi8PLLL2PPnj3o1q0bnJxMi15XrlwpW3BETZGhpLzaJ+yAB72e+IQdEZFtqlfStHfvXnTs2BEAzArBiahmhpJyhG9MwZ2CMrPu4MYmmJ5uSsSN78PEiYjIxlicNK1YsQIbN27Em2++2QDhEDVthaUVuFNQZrasStWu4cZxTJqIiGyLxTVNKpUK/fr1a4hYiJo8H+2D7uDtPFzExCn1Wp7JMiubJ3GZFSIiW2Rx0jRz5kx88sknDRELUbNgXFbFmDiNiE0yW6+OiIhsj8W351JSUrB//37s3LkTXbp0MSsE//7772ULjqip0rk7Y1VoAEbEJonbVoUGMGEiIrJhFidN7u7uGD58eEPEQtRsZOUXIzL+tMm2yPjTnGkiIrJhFidNX331VUPEQdRsVC36bufhglWhAYiMP21WHE5ERLal3m29b9++jcOHD+Pw4cO4ffu2nDERNVm39MVmRd+9/DzMisNv6YsbO1QiInqIxUlTYWEhxo8fDx8fHwwcOBADBw6ETqdDREQEioqKGiJGoibDVeUITzelWdF31eJwTzclXFUWTwITEVEDszhpioqKwqFDh7Bjxw7k5+cjPz8f//d//4dDhw5h9uzZDREjUZOhUTshbnwfxE82vwWnc3dG/OS+bGxJRGSjLP7f2a1bt+Kf//wn/vSnP4nbBg8eDGdnZ7z++uuIjY2VMz6iJkejdqoxKWJ/JiIi22XxTFNRURG8vLzMtrdp04a354hkZCgpr7G26Za+GIaScitHRETUvFmcNAUFBWHRokUoKSkRtxUXF+O9995DUFCQrMERNVfGNepC1ycjK980ccrKL0bo+mSEb0xh4kREZEUW355bvXo1QkJC0LZtWwQEBAAATp8+DbVajb1798oeIFFzxDXqiIhsj8UzTV27dsXly5cRExODHj16oEePHli6dCkuX76MLl26NESMRM0O16gjIrI99erT5OLigokTJ2LFihVYsWIFJkyYAGdn+f/yvn//PhYsWID27dvD2dkZTz75JN5//30IgiCOEQQBCxcuhI+PD5ydnREcHIzLly+bHCcvLw+jR4+GRqOBu7s7IiIiUFBQYDLmzJkzGDBgANRqNXx9fbF8+XLZz4fIElyjjojItlicNMXExGDjxo1m2zdu3Ihly5bJEpTRsmXLEBsbi08//RTp6elYtmwZli9fbrJg8PLly7FmzRqsW7cOx44dg6urK0JCQkxqrkaPHo3z588jISEBO3fuRGJiIiZNmiTuNxgMGDRoEPz8/JCamoqPPvoIixcvxoYNG2Q9HyJLGdeoq4pr1BERNQ6Lk6b169ejU6dOZtu7dOmCdevWyRKU0dGjR/Hqq69iyJAheOKJJ/Daa69h0KBBSElJAfBglunvf/873n33Xbz66qvo3r07/vGPfyArKwvbt28HAKSnp2PPnj344osvEBgYiP79++OTTz7B5s2bkZWVBQD4+uuvUVZWho0bN6JLly4ICwvDjBkzsHLlSlnPh8hSNa1R93BxOBERNTyLk6bs7Gz4+PiYbW/dujVu3bolS1BGzz77LPbt24dLly4BeFBwfvjwYbz00ksAgMzMTGRnZyM4OFj8jFarRWBgIJKSHqwen5SUBHd3d/Tu3VscExwcDAcHBxw7dkwcM3DgQCiVSnFMSEgIMjIycPfu3WpjKy0thcFgMHkRyenhNeq2TgkyqXFi4kREZF0WJ02+vr44cuSI2fYjR45Ap9PJEpTR3LlzERYWhk6dOsHJyQlPP/00Zs2ahdGjRwN4kMABMOsb5eXlJe7Lzs5GmzZtTPY7OjrCw8PDZEx1x6j6HQ+LiYmBVqsVX76+vo94tkS/4xp1RES2x+KkaeLEiZg1axa++uorXLt2DdeuXcPGjRsRGRmJiRMnyhrcd999h6+//hrffPMNTp48ibi4OHz88ceIi4uT9XvqY968edDr9eLrxo0bjR0SNSFS16irFAQ2wCQishKL+zTNmTMHd+7cwdSpU1FWVgYAUKvViI6Oxrx582QNbs6cOeJsEwB069YN165dQ0xMDMLDw+Ht7Q0AyMnJMbllmJOTgx49egAAvL29kZuba3LciooK5OXliZ/39vZGTk6OyRjje+OYh6lUKqhUqkc/SaJqGNeoKyytMGsrYFyjrlIQMP2bU7hTUGb2NJ3x1p6nm5Jr2RERycTimSaFQoFly5bh9u3bSE5OxunTp5GXl4eFCxfKHlxRUREcHExDbNGiBSorKwEA7du3h7e3N/bt2yfuNxgMOHbsmNidPCgoCPn5+UhNTRXH7N+/H5WVlQgMDBTHJCYmorz89/8rT0hIQMeOHdGqVSvZz4tICo3aqcY+TD5aZzgoFCYNMI01TlVroe4UlKGwtMKaYRMRNVn16tMEAG5ubnjmmWfQtWvXBptxGTp0KD744APs2rULv/76K7Zt24aVK1fiL3/5C4AHCdysWbPwt7/9DT/88APOnj2LsWPHQqfTYdiwYQCAzp0748UXX8TEiRORkpKCI0eOYPr06QgLCxNrsEaNGgWlUomIiAicP38e8fHxWL16NaKiohrkvIjkwAaYRETWpRCqdoq0Mffu3cOCBQuwbds25ObmQqfTYeTIkVi4cKH4pJsgCFi0aBE2bNiA/Px89O/fH5999hk6dOggHicvLw/Tp0/Hjh074ODggBEjRmDNmjVwc3MTx5w5cwbTpk3D8ePH8dhjj+Htt99GdHS05FgNBgO0Wi30ej00Go1s16CorAL+Cx8sT3NhSQhclBbfUaUm7uGlVQCwASYRkUSW/H7bdNJkT5g0UWNKvZaHEbFJ4vutU4LQy8+jESMiIrIPlvx+1/v2HBHZhroaYBpKyvmEHRGRDCQlTT179hSbPC5ZsgRFRUV1fIKIrKGuBpiXsu8hfGMKQtebN8PMyi9G6PpkhG9MYeJERCSBpKQpPT0dhYWFAID33nvPbLFbIrI+KQ0w39yUglxDCZ+wIyKSgaQCmR49emDcuHHo378/BEHAxx9/bFJEXVVDtB4gInPGBpgAqm2AaezTtGxEd0yIOyEmTqtCAxAZf5pP2BERWUhSIXhGRgYWLVqEX375BSdPnoS/vz8cHc3zLYVCgZMnTzZIoLaOheDUGAwl5dU2wAQezES5qhyhUTvxCTsiohpY8vst6Re4Y8eO2Lx5MwDAwcEB+/btM1vPjYisT6N2qrHbd9VESufujFWhASZP2K0KDWDCRERkAYufnqusrGTCRGRn6nrCjoiI6lavlgO//PIL3n77bQQHByM4OBgzZszAL7/8IndsRCSDup6wY+JERCSNxUnT3r174e/vj5SUFHTv3h3du3fHsWPH0KVLFyQkJDREjERUT1KesAvbkIzLOffYy4mIqA4WVxXPnTsXkZGRWLp0qdn26Oho/Nd//ZdswRHRo5HyhJ27ixNmbzmN/KJys8Jw4yyVp5sSceP71Fg/RUTUHFg805Seno6IiAiz7ePHj8eFCxdkCYqI5KFROyFufB/ETzZ/Sk7n7oz4yX3x8V8DkF9Uzl5ORER1sDhpat26NdLS0sy2p6WlsUCcyAZp1E419mHy0Tqjg1dLs9t1qdfyzG7rsZcTETV3Ft+emzhxIiZNmoSrV6/i2WefBQAcOXIEy5YtQ1RUlOwBElHDq3q77npekdiagL2ciIh+Z3HStGDBArRs2RIrVqzAvHnzAAA6nQ6LFy/GjBkzZA+QiKyDvZyIiGpn8e05hUKByMhI3Lx5E3q9Hnq9Hjdv3sTMmTOhUCgaIkYisgL2ciIiql29+jQZtWzZEi1btpQrFiJqJFJ6ORlKytmWgIiaNS5kRtTMVdfL6eEap9fXJcHdxQmGkgq2JSCiZuuRZpqIyP4Zezk9XPRtTJzaebhA6+KE/GK2JSCi5o0zTUTNnLGXU2FphVlbAWMvJ1eVIwpKKsQEKWxDMlaFBiAy/jTbEhBRs2HRTFN5eTleeOEFXL58uaHiIaJGUFcvJ43ayWTmydiW4OFbekRETZlFSZOTkxPOnDnTULEQkY0ztiWo6uG2BCwYJ6KmyuKapjfeeANffvllQ8RCRDaurrYEhpJyhG9MQej6ZLNWBVn5xQhdn4zwjSlMnIjILllc01RRUYGNGzfi559/Rq9eveDq6mqyf+XKlbIFR0S24+G2BFVrmsI2JGPzpL5QKIA7BWUm23TuziafBYDC0go+ZUdEdsfimaZz586hZ8+eaNmyJS5duoRTp06Jr+rWpCMi+1ddW4Jefh5ma9YB4Dp2RNRkWTzTdODAgYaIg4hsmLEtAYBq2xIY+zS5qhyhUTtxHTsiapLq3XLgypUr+OWXXzBw4EA4OztDEAQuo0LUREltS2C85cZ17IioKbL49tydO3fwwgsvoEOHDhg8eDBu3boFAIiIiMDs2bNlD5CIbIOUtgRGUgrG+YQdEdkbi5OmyMhIODk54fr163BxcRG3h4aGYs+ePbIGR0T2p6517C5l3+MTdkRklyxOmn766ScsW7YMbdu2Ndn+xz/+EdeuXZMtMCKyP1IKxt/clIJcQwmXZCEiu2Nx0lRYWGgyw2SUl5cHlUolS1BEZJ+krGPnpVHjq3F9+IQdEdkdi5OmAQMG4B//+If4XqFQoLKyEsuXL8fzzz8va3BEZF+MBePxk82fkjMWjMeN74MOXi25JAsR2R2Lk6bly5djw4YNeOmll1BWVoZ33nkHXbt2RWJiIpYtWyZ7gL/99hveeOMNeHp6wtnZGd26dcOJEyfE/YIgYOHChfDx8YGzszOCg4PN1sbLy8vD6NGjodFo4O7ujoiICBQUFJiMOXPmDAYMGAC1Wg1fX18sX75c9nMhag6kFoxLWZKFiMiWWJw0de3aFZcuXUL//v3x6quvorCwEMOHD8epU6fw5JNPyhrc3bt30a9fPzg5OeHHH3/EhQsXsGLFCrRq1Uocs3z5cqxZswbr1q3DsWPH4OrqipCQEJSUlIhjRo8ejfPnzyMhIQE7d+5EYmIiJk2aJO43GAwYNGgQ/Pz8kJqaio8++giLFy/Ghg0bZD0fIvpdXU/YERHZGoUgCEJjB1GTuXPn4siRI/jXv/5V7X5BEKDT6TB79mz893//NwBAr9fDy8sLmzZtQlhYGNLT0+Hv74/jx4+jd+/eAIA9e/Zg8ODBuHnzJnQ6HWJjYzF//nxkZ2dDqVSK3719+3ZcvHhRUqwGgwFarRZ6vR4ajUaGs3+gqKwC/gv3AgAuLAmBi7LerbWIbEZtS7IYb9G5qR2r7QsFPCg4r9oXioioviz5/bZ4pgl4MAP08ccfIyIiAhEREVixYgXy8vLqFWxtfvjhB/Tu3Rt//etf0aZNGzz99NP4/PPPxf2ZmZnIzs5GcHCwuE2r1SIwMBBJSQ+a6iUlJcHd3V1MmAAgODgYDg4OOHbsmDhm4MCBYsIEACEhIcjIyMDdu3erja20tBQGg8HkRUR1k/KE3evrkjBqQzLbEhCRTbE4aUpMTMQTTzyBNWvW4O7du7h79y7WrFmD9u3bIzExUdbgrl69itjYWPzxj3/E3r17MWXKFMyYMQNxcXEAgOzsbACAl5eXyee8vLzEfdnZ2WjTpo3JfkdHR3h4eJiMqe4YVb/jYTExMdBqteLL19f3Ec+WqHmQ8oSd1sUJ+cXlbEtARDbF4ns906ZNQ2hoKGJjY9GiRQsAwP379zF16lRMmzYNZ8+elS24yspK9O7dGx9++CEA4Omnn8a5c+ewbt06hIeHy/Y99TFv3jxERUWJ7w0GAxMnIgmkLslSUFIhJkhhG5KrvYXHtgREZE0WzzRduXIFs2fPFhMmAGjRogWioqJw5coVWYPz8fGBv7+/ybbOnTvj+vXrAABvb28AQE5OjsmYnJwccZ+3tzdyc3NN9ldUVCAvL89kTHXHqPodD1OpVNBoNCYvIpJGyhN2VWee2JaAiGyBxUlTz549kZ6ebrY9PT0dAQEB1Xyi/vr164eMjAyTbZcuXYKfnx8AoH379vD29sa+ffvE/QaDAceOHUNQUBAAICgoCPn5+UhNTRXH7N+/H5WVlQgMDBTHJCYmorz89/qIhIQEdOzY0eRJPSKyLrYlICJbIun23JkzZ8Q/z5gxAzNnzsSVK1fQt29fAEBycjLWrl2LpUuXyhpcZGQknn32WXz44Yd4/fXXkZKSgg0bNoitABQKBWbNmoW//e1v+OMf/4j27dtjwYIF0Ol0GDZsGIAHM1MvvvgiJk6ciHXr1qG8vBzTp09HWFgYdDodAGDUqFF47733EBERgejoaJw7dw6rV6/GqlWrZD0fIrJMTW0JjDNNhpJyPmFHRFYjqeWAg4MDFAoF6hqqUChw//592YIDgJ07d2LevHm4fPky2rdvj6ioKEycOFHcLwgCFi1ahA0bNiA/Px/9+/fHZ599hg4dOohj8vLyMH36dOzYsQMODg4YMWIE1qxZAzc3N3HMmTNnMG3aNBw/fhyPPfYY3n77bURHR0uOky0HiORVV1uCL8b2RvT3Z3CnoMzsdp3xs55uSsSN78PEiYhqZMnvt6SkyZKFeI23zpobJk1E8rmlf9BW4OEapqqJlM5dDQWA3/JLahzTzsMF8ZNZME5ENbPk91vSL3BzTYSIqHEY2xIAqLYtgXEWadmI7pgQd4JP2BGRVdSrI3hWVhYOHz6M3NxcVFZWmuybMWOGbMHZE840EclLar1S1ZklIz5hR0RSyT7TVNWmTZswefJkKJVKeHp6QqFQiPsUCkWzTZqISF4atVONtUhVEynjE3YjYpPEbVWfsGOxOBHJxeKWAwsWLMDChQuh1+vx66+/IjMzU3xdvXq1IWIkIqpRbQv/GkrKEb4xhcuxEJEsLE6aioqKEBYWBgeHei1bR0Qkm4eLvrdOCRKbYYZtSMbV3ALcKSjjcixEJAuLM5+IiAhs2bKlIWIhIpJMysK/MzanYc3IHiaJVOq1PLPPsViciKSwuKYpJiYGL7/8Mvbs2YNu3brBycm0FmDlypWyBUdEVBOpT9j9obWb+N64HAvAYnEisly9kqa9e/eiY8eOAGBWCE5EZA1SF/41FpTXVixORCSFxUnTihUrsHHjRrz55psNEA4RkXRSn7CrazkWIiIpLK5pUqlU6NevX0PEQkQku7qKxR9+qo6IqCYWJ00zZ87EJ5980hCxEBHJSkqxeNiGZNzSP2hPcEtffQJl3E9EzZvFt+dSUlKwf/9+7Ny5E126dDErBP/+++9lC46I6FFILRavFASEb0zh4r9EVCuLkyZ3d3cMHz68IWIhIpKV1GLxwtIKk35O1S3+CwCFpRVMmoiaMYuTpq+++qoh4iAiahBSisU1aieTtgRc/JeIqsO23kRE+P2WnbHWaURskknCxKfsiMjimab27dvX2o+J688Rkb2qa/FfImreLE6aZs2aZfK+vLwcp06dwp49ezBnzhy54iIisjr2cyKi2licNM2cObPa7WvXrsWJEyceOSAiosbwcD+nqjVNVYvDiaj5kq2m6aWXXsLWrVvlOhwRkdVY0s+JiJov2ZKmf/7zn/Dw8JDrcEREVmPs5/Rw0XfV4nBPNyVcVRZPzhNRE2Lx3wBPP/20SSG4IAjIzs7G7du38dlnn8kaHBGRNViy+C8RNV8WJ03Dhg0zee/g4IDWrVvjT3/6Ezp16iRXXEREViV18V8iar4sTpoWLVrUEHEQERER2TQ2tyQiIiKSQPJMk4ODQ61NLQFAoVCgoqLikYMiIiIisjWSk6Zt27bVuC8pKQlr1qxBZWWlLEERERER2RrJSdOrr75qti0jIwNz587Fjh07MHr0aCxZskTW4IiIiIhsRb1qmrKysjBx4kR069YNFRUVSEtLQ1xcHPz8/OSOj4iIiMgmWJQ06fV6REdH46mnnsL58+exb98+7NixA127dm2o+IiIiIhsguTbc8uXL8eyZcvg7e2Nb7/9ttrbdURERERNleSkae7cuXB2dsZTTz2FuLg4xMXFVTvu+++/ly04IiIiIlshOWkaO3ZsnS0HiIiIiJoqyUnTpk2bGjAMaZYuXYp58+Zh5syZ+Pvf/w4AKCkpwezZs7F582aUlpYiJCQEn332Gby8vMTPXb9+HVOmTMGBAwfg5uaG8PBwxMTEwNHx99M/ePAgoqKicP78efj6+uLdd9/Fm2++aeUzJCIiIltlNx3Bjx8/jvXr16N79+4m2yMjI7Fjxw5s2bIFhw4dQlZWFoYPHy7uv3//PoYMGYKysjIcPXoUcXFx2LRpExYuXCiOyczMxJAhQ/D8888jLS0Ns2bNwoQJE7B3716rnR8RERHZNrtImgoKCjB69Gh8/vnnaNWqlbhdr9fjyy+/xMqVK/HnP/8ZvXr1wldffYWjR48iOTkZAPDTTz/hwoUL+N///V/06NEDL730Et5//32sXbsWZWVlAIB169ahffv2WLFiBTp37ozp06fjtddew6pVq2qMqbS0FAaDweRFRERETZddJE3Tpk3DkCFDEBwcbLI9NTUV5eXlJts7deqEdu3aISkpCcCDbuXdunUzuV0XEhICg8GA8+fPi2MePnZISIh4jOrExMRAq9WKL19f30c+TyIiIrJdNp80bd68GSdPnkRMTIzZvuzsbCiVSri7u5ts9/LyQnZ2tjimasJk3G/cV9sYg8GA4uLiauOaN28e9Hq9+Lpx40a9zo+IiIjsg+RC8MZw48YNzJw5EwkJCVCr1Y0djgmVSgWVStXYYRAREZGV2PRMU2pqKnJzc9GzZ084OjrC0dERhw4dwpo1a+Do6AgvLy+UlZUhPz/f5HM5OTnw9vYGAHh7eyMnJ8dsv3FfbWM0Gg2cnZ0b6OyIyN4YSspxS1/97PMtfTEMJeVWjoiIrMmmk6YXXngBZ8+eRVpamvjq3bs3Ro8eLf7ZyckJ+/btEz+TkZGB69evIygoCAAQFBSEs2fPIjc3VxyTkJAAjUYDf39/cUzVYxjHGI9BRGQoKUf4xhSErk9GVr5p4pSVX4zQ9ckI35jCxImoCbPp23MtW7Y0W9fO1dUVnp6e4vaIiAhERUXBw8MDGo0Gb7/9NoKCgtC3b18AwKBBg+Dv748xY8Zg+fLlyM7Oxrvvvotp06aJt9feeustfPrpp3jnnXcwfvx47N+/H9999x127dpl3RMmIptVWFqBOwVluJ5XhLANydg8qS907s7Iyi9G2IZkXM8rEsdp1E6NHC0RNQSbnmmSYtWqVXj55ZcxYsQIDBw4EN7e3iZLubRo0QI7d+5EixYtEBQUhDfeeANjx47FkiVLxDHt27fHrl27kJCQgICAAKxYsQJffPEFQkJCGuOUiMgG+WidsXlSX7TzcBETp9RreWLC1M7DBZsn9YWPlrf0iZoqhSAIQmMH0RQYDAZotVro9XpoNBrZjltUVgH/hQ+abF5YEgIXpU1PDhI1eQ/PLAEQEyadOxMmIntjye+33c80ERFZk87dGatCA0y2rQoNEBMmFosTNV1MmoiILJCVX4zI+NMm2yLjTyMrv5jF4kRNHJMmIiKJqt6aa+fhgq1TgkxqnK7mFpgUixsTp6qfu1NQhsLSikY+EyKqDyZNREQS3NIXmxV99/LzMCkOn7E5DWtG9mCxOFETxaSJiEgCV5UjPN2UZkXfOvffn6rzdFPiD63dTBKpEbFJJgkTi8WJ7BcfxSIikkCjdkLc+D4oLK0wmynSuTsjfnJfuKocoVE7QaN2wqrQAIyI/X3R76rF4kRknzjTREQkkUbtVOOtNR+ts9jUsrZicYBP2BHZKyZNREQyqqtY/FL2PT5hR2SnmDQREclESrH4m5tSkGso4RN2RHaISRMRkUykFIt7adT4alwfPmFHZIe4jIpMuIwKEQEP6pWqKxYHHsxEGYvFuRwLkW3gMipERI1EarF4XcuxEJHtYdJERNQI+IQdkf1h0kREZGV8wo7IPjFpIiKyIj5hR2S/mDQREVkRn7Ajsl98ek4mfHqOiKTiE3ZEtoNPzxER2TA5n7BjwTiR9TBpIiKyUVKesGPBOJH1MGkiIrJBdT1hl5VfjMLSCtwpKGPBOJGVMGkiIrIxUp6wC9uQDABm21gwTtRwmDQREdkYKU/Yebop4apyNNl2Pa8II2KTTBImFowTyYePYhER2RiN2glx4/tU+4Sdzt0Z8ZP7ik/YGbetCg3AiNgkcVzVgnGpT+sRUe0400REZIOkPmEH1F4wzmJxIvkwaSIismN1FYxfzS1gsTiRTJg0ERHZKSkF4zM2p2HNyB51Fou7qhzZ74moDkyaiIjslNSC8T+0dqu1WNxN7chbeEQSMGkiIrJTxoLx+MnmT8kZC8bjxveBRu1Ua3dx9nsikoZJExGRHZNaMF5bsbiP1pn9nogkYNJERNTESekuLqXfE9e5o+aOSRMRURMmtbv4LX1xrbfw2LqAyA6SppiYGDzzzDNo2bIl2rRpg2HDhiEjI8NkTElJCaZNmwZPT0+4ublhxIgRyMnJMRlz/fp1DBkyBC4uLmjTpg3mzJmDigrT+/MHDx5Ez549oVKp8NRTT2HTpk0NfXpERA3Kku7itd3CY90TkR0kTYcOHcK0adOQnJyMhIQElJeXY9CgQSgsLBTHREZGYseOHdiyZQsOHTqErKwsDB8+XNx///59DBkyBGVlZTh69Cji4uKwadMmLFy4UByTmZmJIUOG4Pnnn0daWhpmzZqFCRMmYO/evVY9XyIiOUktFi8oqaj1Fp4gSFvnjq0LqClTCIIgNHYQlrh9+zbatGmDQ4cOYeDAgdDr9WjdujW++eYbvPbaawCAixcvonPnzkhKSkLfvn3x448/4uWXX0ZWVha8vLwAAOvWrUN0dDRu374NpVKJ6Oho7Nq1C+fOnRO/KywsDPn5+dizZ0+dcRkMBmi1Wuj1emg0GtnOt6isAv4LHyRuF5aEwEXJlW+ISF639A9urz1cw/RwLVT85L4QBIjbjB5uXXCnoMxs3TvjsTzdlIgb3wcAuLQL2QRLfr9tfqbpYXq9HgDg4eEBAEhNTUV5eTmCg4PFMZ06dUK7du2QlPRgHaakpCR069ZNTJgAICQkBAaDAefPnxfHVD2GcYzxGA8rLS2FwWAweRER2SNLFwh+1NYFOfoS1keRXbKrpKmyshKzZs1Cv3790LVrVwBAdnY2lEol3N3dTcZ6eXkhOztbHFM1YTLuN+6rbYzBYEBxsflUc0xMDLRarfjy9fWV5RyJiKzNkn5PcrQucFM7Sk6ueKuPbIldJU3Tpk3DuXPnsHnz5sYOBfPmzYNerxdfN27caOyQiIjqTUq/J7laF0hJrr4Y2xvvbD3D2SiyKXaTNE2fPh07d+7EgQMH0LZtW3G7t7c3ysrKkJ+fbzI+JycH3t7e4piHn6Yzvq9rjEajgbOz+V8kKpUKGo3G5EVE1FTJ1brAqK7kqqWztNkoPq1H1mTzSZMgCJg+fTq2bduG/fv3o3379ib7e/XqBScnJ+zbt0/clpGRgevXryMoKAgAEBQUhLNnzyI3N1cck5CQAI1GA39/f3FM1WMYxxiPQUTUnMnVuqCq2pIrqbf6+LQeWZPNPz03depUfPPNN/i///s/dOzYUdyu1WrFGaApU6Zg9+7d2LRpEzQaDd5++20AwNGjRwE8aDnQo0cP6HQ6LF++HNnZ2RgzZgwmTJiADz/8EMCDlgNdu3bFtGnTMH78eOzfvx8zZszArl27EBISUmecfHqOiJo6Q0l5nU+8Pdy6YFVoACLjT5vdogNMZ42MLBljydN6fBKPatKknp6LjY2FXq/Hn/70J/j4+Iiv+Ph4ccyqVavw8ssvY8SIERg4cCC8vb3x/fffi/tbtGiBnTt3okWLFggKCsIbb7yBsWPHYsmSJeKY9u3bY9euXUhISEBAQABWrFiBL774QlLCRETUHNRV91RYWiH5Fp6U+iig9tkoNtwka7P5mSZ7wZkmImrujEut1DXzs2xEd0yIO/HIfaGq+0xtM1tE1WlSM01ERGQfpLYu8NaqJdVH3aujSzkXGiZr40yTTDjTREQkXV31UfdKKiTPRvlonZF6LQ8jYn9vRrx1ShB6+XlInv1i3VPzxZkmIiKyaXXVR0mdjZJzoWHOSFFdmDQREZHNaYyFhqUs7fJbfhETq2aMSRMREdkkuZ7WUyhQZ92TlBmp24ZSTP5HKruUN2NMmoiIyC7JtdAwAEnNND8d9TQMJRVcM68ZYyG4TFgITkRkfVIabj68bp5RdS0J6hpXV4uDL8b2RvT3Z+osPP901NNwUCjqjJsaHgvBiYioWZBroWGjumak5FgzT+ptPtZP2R4mTURE1GRZstAwAEnr5j3qmnlSbvOxfso2MWkiIqImy9KFhqXMSNWVWNU1G9WjXSvZ6qfYKsG6WNMkE9Y0ERHZJil1T4WlFQhdn2z2VN3DidSakT0w49s0Scu21NRw0+hR66csWbRYSg0VAEn1YU0Na5qIiIj+Q0rdk5QZqZZqR0z/5pTkBYkf5Tbfw9/d0K0S3vjiGN744hjrrOrApImIiJo9Kc00N4zthdYtVbKsmQc8ev0UIF+rhH8XlOJOQSkL2OvA23My4e05IqKmT64186Te5rNWq4TNk/oCQK1j1oT1wIzNabXG2NbdGe4uTjCUVNS51h9gG7cDeXuOiIioAcixZp7U23xpN+5arVWCzt3ZqgXsOfoSScvW2NqsFJMmIiIimch1m8+S+ilAnlt9UsbIkVgZC9ilLqRsS5g0ERERyaiu2ajH3V1kq5+Ss1WC1DFyzGpJqcXaPKlvjdexsbCmSSasaSIiIjlZu1UCUHtNk6V1VnW1XADqrsWyBtY0ERER2Tlrtkp4bd1R/HXdUdnqrKTMWBnjrOuWoS3hTJNMONNERESNoa4ZqUpBwPRvTtXaANPd5cFTavlF5TWOaal2hL64HDfvFsvWANTeZpqYNMmESRMREdkqKbf6gNpbAEhJvqQmVvGT+0IQpN0ObGhMmhoBkyYiImrq5JjV8nRTYtmI7pL6WcVPbvhicEt+v/kLTERERJJo1E41Npw0Jjdx4/tUm1gZnww0zmp5uikBoNpaLGNyZRxrK2wrGiIiIrJrUhIrQFpyZWsLBDNpIiIiIquTmlzZErYcICIiIpKASRMRERGRBEyaiIiIiCRg0kREREQkAZMmIiIiIgmYNBEREZFNMpSU45a+uNp9t/TFMJSUWzUeJk0PWbt2LZ544gmo1WoEBgYiJSWlsUMiIiJqdgwl5QjfmILQ9clmC/1m5RcjdH0ywjemWDVxYtJURXx8PKKiorBo0SKcPHkSAQEBCAkJQW5ubmOHRkRE1KwUllbgTkEZrucVIWzD74lT1aVW7hSUobC0wmoxMWmqYuXKlZg4cSLGjRsHf39/rFu3Di4uLti4cWNjh0ZERNSs+GgfLKnSzsNFTJxSr+WZrE23eVLDr01XFZOm/ygrK0NqaiqCg4PFbQ4ODggODkZSUpLZ+NLSUhgMBpMXERERyce4Fp0xcRoRm2S2yK81MWn6j3//+9+4f/8+vLy8TLZ7eXkhOzvbbHxMTAy0Wq348vX1tVaoREREzYbO3RmrQgNMtq0KDbB6wgQwaaq3efPmQa/Xi68bN240dkhERERNTlZ+MSLjT5tsi4w/bVYcbg1Mmv7jscceQ4sWLZCTk2OyPScnB97e3mbjVSoVNBqNyYuIiIjkU7Xou52HC7ZOCTKpcbJ24sSk6T+USiV69eqFffv2idsqKyuxb98+BAUFNWJkREREzc8tfbFZ0XcvPw+z4vCa+jg1BCZNVURFReHzzz9HXFwc0tPTMWXKFBQWFmLcuHGNHRoREVGz4qpyhKeb0qzou2pxuKebEq4qR6vFZL1vsgOhoaG4ffs2Fi5ciOzsbPTo0QN79uwxKw4nIiKihqVROyFufB8UllaYtRXQuTsjfnJfuKocoVE7WS0mJk0PmT59OqZPn97YYRARETV7GrVTjUmRNfszGfH2HBEREZEETJqIiIiIJGDSRERERCQBkyYiIiIiCZg0EREREUnApImIiIhIAiZNRERERBIwaSIiIiKSgEkTERERkQTsCC4TQRAAAAaDQdbjFpVVoLK0SDx2hZL/yIiIiORi/N02/o7XRiFIGUV1unnzJnx9fRs7DCIiIqqHGzduoG3btrWOYdIkk8rKSmRlZaFly5ZQKBSyHttgMMDX1xc3btyARqOR9dj0O15n6+B1tg5eZ+vhtbaOhrrOgiDg3r170Ol0cHCovWqJ93pk4uDgUGeG+qg0Gg3/g7QCXmfr4HW2Dl5n6+G1to6GuM5arVbSOBaCExEREUnApImIiIhIAiZNdkClUmHRokVQqVSNHUqTxutsHbzO1sHrbD281tZhC9eZheBEREREEnCmiYiIiEgCJk1EREREEjBpIiIiIpKASRMRERGRBEyabMTatWvxxBNPQK1WIzAwECkpKbWO37JlCzp16gS1Wo1u3bph9+7dVorUvllynT///HMMGDAArVq1QqtWrRAcHFznPxd6wNJ/n402b94MhUKBYcOGNWyATYSl1zk/Px/Tpk2Dj48PVCoVOnTowL87JLD0Ov/9739Hx44d4ezsDF9fX0RGRqKkpMRK0dqnxMREDB06FDqdDgqFAtu3b6/zMwcPHkTPnj2hUqnw1FNPYdOmTQ0eJwRqdJs3bxaUSqWwceNG4fz588LEiRMFd3d3IScnp9rxR44cEVq0aCEsX75cuHDhgvDuu+8KTk5OwtmzZ60cuX2x9DqPGjVKWLt2rXDq1CkhPT1dePPNNwWtVivcvHnTypHbF0uvs1FmZqbw+OOPCwMGDBBeffVV6wRrxyy9zqWlpULv3r2FwYMHC4cPHxYyMzOFgwcPCmlpaVaO3L5Yep2//vprQaVSCV9//bWQmZkp7N27V/Dx8REiIyOtHLl92b17tzB//nzh+++/FwAI27Ztq3X81atXBRcXFyEqKkq4cOGC8MknnwgtWrQQ9uzZ06BxMmmyAX369BGmTZsmvr9//76g0+mEmJiYase//vrrwpAhQ0y2BQYGCpMnT27QOO2dpdf5YRUVFULLli2FuLi4hgqxSajPda6oqBCeffZZ4YsvvhDCw8OZNElg6XWOjY0V/vCHPwhlZWXWCrFJsPQ6T5s2Tfjzn/9ssi0qKkro169fg8bZlEhJmt555x2hS5cuJttCQ0OFkJCQBoxMEHh7rpGVlZUhNTUVwcHB4jYHBwcEBwcjKSmp2s8kJSWZjAeAkJCQGsdT/a7zw4qKilBeXg4PD4+GCtPu1fc6L1myBG3atEFERIQ1wrR79bnOP/zwA4KCgjBt2jR4eXmha9eu+PDDD3H//n1rhW136nOdn332WaSmpoq38K5evYrdu3dj8ODBVom5uWis30Eu2NvI/v3vf+P+/fvw8vIy2e7l5YWLFy9W+5ns7Oxqx2dnZzdYnPauPtf5YdHR0dDpdGb/odLv6nOdDx8+jC+//BJpaWlWiLBpqM91vnr1Kvbv34/Ro0dj9+7duHLlCqZOnYry8nIsWrTIGmHbnfpc51GjRuHf//43+vfvD0EQUFFRgbfeegv/7//9P2uE3GzU9DtoMBhQXFwMZ2fnBvlezjQRSbB06VJs3rwZ27Ztg1qtbuxwmox79+5hzJgx+Pzzz/HYY481djhNWmVlJdq0aYMNGzagV69eCA0Nxfz587Fu3brGDq1JOXjwID788EN89tlnOHnyJL7//nvs2rUL77//fmOHRjLgTFMje+yxx9CiRQvk5OSYbM/JyYG3t3e1n/H29rZoPNXvOht9/PHHWLp0KX7++Wd07969IcO0e5Ze519++QW//vorhg4dKm6rrKwEADg6OiIjIwNPPvlkwwZth+rz77OPjw+cnJzQokULcVvnzp2RnZ2NsrIyKJXKBo3ZHtXnOi9YsABjxozBhAkTAADdunVDYWEhJk2ahPnz58PBgXMVcqjpd1Cj0TTYLBPAmaZGp1Qq0atXL+zbt0/cVllZiX379iEoKKjazwQFBZmMB4CEhIQax1P9rjMALF++HO+//z727NmD3r17WyNUu2bpde7UqRPOnj2LtLQ08fXKK6/g+eefR1paGnx9fa0Zvt2oz7/P/fr1w5UrV8SkFAAuXboEHx8fJkw1qM91LioqMkuMjImqwKVeZdNov4MNWmZOkmzevFlQqVTCpk2bhAsXLgiTJk0S3N3dhezsbEEQBGHMmDHC3LlzxfFHjhwRHB0dhY8//lhIT08XFi1axJYDElh6nZcuXSoolUrhn//8p3Dr1i3xde/evcY6Bbtg6XV+GJ+ek8bS63z9+nWhZcuWwvTp04WMjAxh586dQps2bYS//e1vjXUKdsHS67xo0SKhZcuWwrfffitcvXpV+Omnn4Qnn3xSeP311xvrFOzCvXv3hFOnTgmnTp0SAAgrV64UTp06JVy7dk0QBEGYO3euMGbMGHG8seXAnDlzhPT0dGHt2rVsOdCcfPLJJ0K7du0EpVIp9OnTR0hOThb3Pffcc0J4eLjJ+O+++07o0KGDoFQqhS5dugi7du2ycsT2yZLr7OfnJwAwey1atMj6gdsZS/99ropJk3SWXuejR48KgYGBgkqlEv7whz8IH3zwgVBRUWHlqO2PJde5vLxcWLx4sfDkk08KarVa8PX1FaZOnSrcvXvX+oHbkQMHDlT7963x2oaHhwvPPfec2Wd69OghKJVK4Q9/+IPw1VdfNXicCkHgfCERERFRXVjTRERERCQBkyYiIiIiCZg0EREREUnApImIiIhIAiZNRERERBIwaSIiIiKSgEkTERERkQRMmoiIiIgkYNJERHbv4MGDUCgUyM/Pt+r3btq0Ce7u7o90jF9//RUKhQJpaWk1jmms8yMiU0yaiMimKRSKWl+LFy9u7BCJqJlwbOwAiIhqc+vWLfHP8fHxWLhwITIyMsRtbm5uOHHihMXHLSsrg1KplCVGImoeONNERDbN29tbfGm1WigUCpNtbm5u4tjU1FT07t0bLi4uePbZZ02Sq8WLF6NHjx744osv0L59e6jVagBAfn4+JkyYgNatW0Oj0eDPf/4zTp8+LX7u9OnTeP7559GyZUtoNBr06tXLLEnbu3cvOnfuDDc3N7z44osmiV5lZSWWLFmCtm3bQqVSoUePHtizZ0+t57x792506NABzs7OeP755/Hrr78+yiUkIpkwaSKiJmP+/PlYsWIFTpw4AUdHR4wfP95k/5UrV7B161Z8//33Yg3RX//6V+Tm5uLHH39EamoqevbsiRdeeAF5eXkAgNGjR6Nt27Y4fvw4UlNTMXfuXDg5OYnHLCoqwscff4z/+Z//QWJiIq5fv47//u//FvevXr0aK1aswMcff4wzZ84gJCQEr7zyCi5fvlztOdy4cQPDhw/H0KFDkZaWhgkTJmDu3LkyXykiqheBiMhOfPXVV4JWqzXbfuDAAQGA8PPPP4vbdu3aJQAQiouLBUEQhEWLFglOTk5Cbm6uOOZf//qXoNFohJKSEpPjPfnkk8L69esFQRCEli1bCps2baoxHgDClStXxG1r164VvLy8xPc6nU744IMPTD73zDPPCFOnThUEQRAyMzMFAMKpU6cEQRCEefPmCf7+/ibjo6OjBQDC3bt3q42DiKyDM01E1GR0795d/LOPjw8AIDc3V9zm5+eH1q1bi+9Pnz6NgoICeHp6ws3NTXxlZmbil19+AQBERUVhwoQJCA4OxtKlS8XtRi4uLnjyySdNvtf4nQaDAVlZWejXr5/JZ/r164f09PRqzyE9PR2BgYEm24KCgiRfAyJqOCwEJ6Imo+ptM4VCAeBBTZGRq6uryfiCggL4+Pjg4MGDZscythJYvHgxRo0ahV27duHHH3/EokWLsHnzZvzlL38x+07j9wqCIMfpEJGN4UwTETVbPXv2RHZ2NhwdHfHUU0+ZvB577DFxXIcOHRAZGYmffvoJw4cPx1dffSXp+BqNBjqdDkeOHDHZfuTIEfj7+1f7mc6dOyMlJcVkW3JysoVnRkQNgUkTETVbwcHBCAoKwrBhw/DTTz/h119/xdGjRzF//nycOHECxcXFmD59Og4ePIhr167hyJEjOH78ODp37iz5O+bMmYNly5YhPj4eGRkZmDt3LtLS0jBz5sxqx7/11lu4fPky5syZg4yMDHzzzTfYtGmTTGdMRI+Ct+eIqNlSKBTYvXs35s+fj3HjxuH27dvw9vbGwIED4eXlhRYtWuDOnTsYO3YscnJy8Nhjj2H48OF47733JH/HjBkzoNfrMXv2bOTm5sLf3x8//PAD/vjHP1Y7vl27dti6dSsiIyPxySefoE+fPvjwww/NngQkIutTCLz5TkRERFQn3p4jIiIikoBJExEREZEETJqIiIiIJGDSRERERCQBkyYiIiIiCZg0EREREUnApImIiIhIAiZNRERERBIwaSIiIiKSgEkTERERkQRMmoiIiIgk+P+Lp094t8QHdwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "thresh = np.linspace(0.0,1.0,50)\n",
+    "probs = notNone_df.prob.to_numpy()\n",
+    "condition = (probs>0.5)\n",
+    "filtered_probs = probs[condition]\n",
+    "num_compounds = [len(probs[(probs>t)]) for t in thresh]\n",
+    "\n",
+    "fig,ax = plt.subplots()\n",
+    "\n",
+    "ax.scatter(x=thresh, y=num_compounds, marker='x')\n",
+    "plt.xlabel('Threshold')\n",
+    "plt.ylabel('Number of compounds')\n",
+    "ax.axvline()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.13 ('m3gnet')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "12ffb9a1fc55ed07279e7dd77ad285a3497c27b3c474e4f9eb992cd6013b4b31"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/Oxidation_states/oxidation_states.ipynb
+++ b/examples/Oxidation_states/oxidation_states.ipynb
@@ -5,10 +5,7 @@
    "metadata": {},
    "source": [
     "# Oxidation states\n",
-    "Here, we will demonstrate the main functionalities of the `oxidation_states` submodule of SMACT.\n",
-    "\n",
-    "TO-DO\n",
-    "* Modify composition generation by SMACT to reproduce exact results from the paper"
+    "Here, we will demonstrate the main functionalities of the `oxidation_states` submodule of SMACT."
    ]
   },
   {
@@ -22,7 +19,20 @@
     "from smact import Species, Element, screening\n",
     "from smact.oxidation_states import Oxidation_state_probability_finder\n",
     "from itertools import combinations, product\n",
-    "import multiprocess"
+    "import multiprocess\n",
+    "import re\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting started with the oxidation_states submodule\n",
+    "\n",
+    "The main class of the `smact.oxidation_states` submodule is `Oxidation_state_probability_finder`. We will demonstrate the usage of the methods of this class below."
    ]
   },
   {
@@ -32,7 +42,7 @@
    "outputs": [],
    "source": [
     "# Instantiate the oxidation state probability finder class with the default table\n",
-    "ox_prob_finder = Oxidation_state_probability_finder()"
+    "ox_prob_finder = Oxidation_state_probability_finder()\n"
    ]
   },
   {
@@ -51,19 +61,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['Te-2', 'Se-2', 'Br-1', 'O-2', 'S-2', 'F-1', 'Cl-1', 'I-1', 'V5', 'Bi1', 'Hg2', 'Eu2', 'Ta1', 'Zr1', 'Pb2', 'Th4', 'Cr4', 'Ti2', 'Be2', 'Sb4', 'Re5', 'Sb3', 'Mo6', 'Ni3', 'Ga2', 'Nd3', 'Ni1', 'Cr6', 'Mn6', 'In3', 'V3', 'La3', 'W3', 'Ho2', 'Ta4', 'Cu1', 'W5', 'Cr3', 'Fe1', 'Re6', 'Rb1', 'Sm3', 'Pd2', 'Ce3', 'Sc2', 'Cr5', 'Tm3', 'W4', 'Pr3', 'Mo2', 'Ag3', 'Ir3', 'Li1', 'Cs1', 'Mn4', 'Al3', 'V4', 'Mn1', 'Rh1', 'Ru5', 'La1', 'Bi5', 'Cd2', 'Ce2', 'Yb3', 'Ru2', 'Ru3', 'Cr2', 'Co3', 'Na1', 'Ru4', 'Ag1', 'Zn2', 'Pb4', 'Mn2', 'Ir6', 'Ta3', 'Tb1', 'K1', 'Ti4', 'Rh3', 'Nb1', 'Ti3', 'Sr2', 'Y3', 'Gd3', 'Ta2', 'Zr2', 'Gd2', 'Th3', 'Lu3', 'Tm2', 'Sn3', 'Ca2', 'Nb3', 'Re3', 'Cu2', 'Er3', 'Bi3', 'V2', 'Fe2', 'Sb5', 'Mg2', 'Ce4', 'Ta5', 'U6', 'Nb2', 'Ag2', 'Re4', 'Yb2', 'In2', 'Ga1', 'Tb3', 'Mn7', 'La2', 'Tl1', 'Bi2', 'Mn3', 'Ho3', 'Rh4', 'Tl3', 'U2', 'Fe4', 'Ge2', 'Mo3', 'Pr2', 'U3', 'W6', 'Ni4', 'Fe3', 'Ga3', 'Ba2', 'In1', 'Re2', 'Sn4', 'Ir4', 'Sn2', 'U4', 'U5', 'Zr3', 'Nb4', 'Zr4', 'Eu3', 'Pd4', 'Y1', 'Hf4', 'Nd2', 'Y2', 'W2', 'Re7', 'Ni2', 'Co1', 'Tb2', 'Dy2', 'Hf2', 'Tb4', 'Mn5', 'Cu3', 'Ir5', 'Sc3', 'Mo4', 'Dy3', 'Co4', 'Ge3', 'Sm2', 'Hg1', 'Nb5', 'Ru6', 'Ge4', 'Sc1', 'Pd3', 'Co2', 'Mo5']\n"
+      "The species included in the probability table for the oxidation states model are show below \n",
+      "['Cl-1', 'O-2', 'I-1', 'S-2', 'Te-2', 'Br-1', 'F-1', 'Se-2', 'U5', 'Pb2', 'Sr2', 'Sc3', 'Eu3', 'Yb2', 'Gd3', 'Ni3', 'Tl1', 'Re7', 'Ti4', 'Y2', 'Hg2', 'Ce4', 'Nb5', 'Ce2', 'Y1', 'Ta5', 'Fe2', 'W4', 'Mo6', 'Cr6', 'Pd4', 'Al3', 'Ag3', 'Sn4', 'Cr2', 'Hf2', 'Tl3', 'Ge3', 'Mn5', 'Eu2', 'Mo5', 'Ge2', 'Pr2', 'Ni1', 'V5', 'La2', 'Sm3', 'Tb4', 'Hf4', 'U3', 'Ga2', 'Mo3', 'Mg2', 'Li1', 'Ge4', 'Ca2', 'Nb1', 'Ru4', 'Pb4', 'Ti2', 'Tm3', 'Mn2', 'Zr2', 'Pd3', 'Sc2', 'Be2', 'Sb3', 'W2', 'In1', 'Nb3', 'Mn7', 'Bi1', 'Cs1', 'Tb1', 'Er3', 'Ni2', 'Ru3', 'Cr3', 'Cr4', 'Ga1', 'Nb4', 'Re6', 'Zn2', 'Sb4', 'Fe3', 'Zr3', 'Rh4', 'U2', 'Th4', 'Na1', 'Th3', 'Ir3', 'Co1', 'Ir5', 'In3', 'V2', 'Ta1', 'Ga3', 'Fe1', 'Pr3', 'Ta2', 'V4', 'Sb5', 'Nb2', 'Lu3', 'Hg1', 'Gd2', 'Tb3', 'Sn3', 'W6', 'Ce3', 'Cd2', 'W3', 'Ta4', 'Ta3', 'Rh1', 'Dy2', 'Ho2', 'Cr5', 'K1', 'Mn3', 'Re2', 'Ag2', 'Fe4', 'Yb3', 'Ag1', 'In2', 'Ru5', 'U4', 'Y3', 'Co2', 'Nd3', 'Sc1', 'V3', 'Co4', 'Cu1', 'Co3', 'La1', 'Nd2', 'Cu3', 'Re4', 'Ir4', 'Ti3', 'Pd2', 'Zr1', 'Sm2', 'W5', 'Bi3', 'Ba2', 'Ni4', 'Dy3', 'Mo4', 'Ho3', 'U6', 'Mo2', 'Ru6', 'Re5', 'Mn1', 'Bi5', 'Mn4', 'Zr4', 'Ru2', 'Rh3', 'Cu2', 'Sn2', 'Tm2', 'Re3', 'Mn6', 'La3', 'Bi2', 'Rb1', 'Tb2', 'Ir6']\n"
      ]
     }
    ],
    "source": [
-    "print(ox_prob_finder.get_included_species())"
+    "included_species = ox_prob_finder.get_included_species()\n",
+    "\n",
+    "print(\n",
+    "    f'The species included in the probability table for the oxidation states model are show below \\n{included_species}')\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can compute the probability of a cation-anion pair appearing together using the method `pair_probability` as demonstrated below for Al<sup>3+</sup> and O<sup>2-</sup>."
+    "We can compute the probability of a cation-anion pair appearing together using the method `pair_probability` as demonstrated below for Al<sup>3+</sup> and O<sup>2-</sup>. The pair probability for a species-anion pair ($P_{SA}$) is given by:\n",
+    "\n",
+    "$P_{SA} = \\frac{N_{SX}}{N_{MX}}$\n",
+    "\n",
+    "where $N_{MX}$ is the total number of compounds containing the metal element M, and X is the most electronegative anion."
    ]
   },
   {
@@ -72,124 +90,214 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "1.0"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " The probability of Al existing in 3+ oxidation states with O in a 2- oxidation state is 1.0\n"
+     ]
     }
    ],
    "source": [
-    "Al=Species('Al', oxidation = 3, coordination=6)\n",
-    "O=Species('O', oxidation=-2, coordination=6)\n",
-    "ox_prob_finder.pair_probability(Al,O)"
+    "Al = Species('Al', oxidation=3, coordination=6)\n",
+    "O = Species('O', oxidation=-2, coordination=6)\n",
+    "\n",
+    "print(\n",
+    "    f' The probability of Al existing in 3+ oxidation states with O in a 2- oxidation state is {ox_prob_finder.pair_probability(Al,O)}')\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's reproduce the results from the publication.\n",
-    "First we will generate the input compositions from the paper."
+    "We can also compute the compound probability which for a ternary compound, A<sub>a</sub>B<sub>b</sub>X<sub>x</sub>, is given by:\n",
+    "\n",
+    "$P_{A_{a}B_{b}X_{x}} = P_{AX}P_{BX} = \\frac{N_{AX}}{N_{M_{A}X}} \\times \\frac{N_{BX}}{N_{M_{B}X}}$\n",
+    "\n",
+    "We will calculate $P_{CaAl_{2}O_{4}}$."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get the elements\n",
-    "\n",
-    "all_el = smact.element_dictionary()\n",
-    "symbol_list = [k for k,i in all_el.items()]\n",
-    "\n",
-    "d_block_symbols = smact.ordered_elements(21,30) + smact.ordered_elements(39,48) + smact.ordered_elements(71,80)\n",
-    "\n",
-    "d_block_elements = [all_el[x] for x in symbol_list if x in d_block_symbols]\n",
-    "\n",
-    "d_block_combos = combinations(d_block_elements,2)\n",
-    "\n",
-    "def smact_filter(els):\n",
-    "    all_compounds = []\n",
-    "    halide_symbols = ['F','Cl','Br','I']\n",
-    "\n",
-    "    for halide in halide_symbols:\n",
-    "        elements = [e.symbol for e in els] +[halide]\n",
-    "\n",
-    "        # Get the Pauling electronegativities\n",
-    "        paul_a, paul_b, paul_x = els[0].pauling_eneg, els[1].pauling_eneg, Element(halide).pauling_eneg\n",
-    "        electronegativities = [paul_a, paul_b, paul_x]\n",
-    "    \n",
-    "        # For each set of species (in oxidation states) apply both SMACT tests\n",
-    "        for ox_a, ox_b in product(els[0].oxidation_states, \n",
-    "                        els[1].oxidation_states):      \n",
-    "            ox_states = [ox_a, ox_b, -1]\n",
-    "            # Test for charge balance\n",
-    "            cn_e, cn_r = smact.neutral_ratios(ox_states, threshold = 8)\n",
-    "            if cn_e:\n",
-    "                # Electronegativity test\n",
-    "                electroneg_OK = screening.pauling_test(ox_states, electronegativities)\n",
-    "                if electroneg_OK:\n",
-    "                    compound = tuple([elements,(ox_a,ox_b,-1),cn_r[0]])\n",
-    "                    all_compounds.append(compound)\n",
-    "    return all_compounds\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of compositions: 38788\n",
-      "Each list entry looks like this:\n",
-      "  elements, oxidation states, stoichiometries\n",
-      "(['Sc', 'Ti', 'F'], (1, -1, -1), (2, 1, 1))\n",
-      "(['Sc', 'Ti', 'F'], (1, 1, -1), (1, 1, 2))\n",
-      "(['Sc', 'Ti', 'F'], (1, 2, -1), (1, 1, 3))\n",
-      "(['Sc', 'Ti', 'F'], (1, 3, -1), (1, 1, 4))\n",
-      "(['Sc', 'Ti', 'F'], (1, 4, -1), (1, 1, 5))\n"
+      "The compound probability for CaAl2O4 is 1.0.\n"
      ]
     }
    ],
    "source": [
-    "with multiprocess.Pool(3) as p:\n",
-    "    result = p.map(smact_filter, d_block_combos)\n",
-    "    \n",
-    "flat_list = [item for sublist in result for item in sublist]\n",
-    "print(\"Number of compositions: {0}\".format(len(flat_list)))\n",
-    "print('Each list entry looks like this:\\n  elements, oxidation states, stoichiometries')\n",
-    "for i in flat_list[:5]:\n",
-    "    print(i)\n"
+    "# Create a list of species for our compound of interest\n",
+    "CaAl2O4 = [Species('Ca', 2), Species('Al', 3), Species('O', -2)]\n",
+    "\n",
+    "prob_compound = ox_prob_finder.compound_probability(CaAl2O4)\n",
+    "\n",
+    "print(f'The compound probability for CaAl2O4 is {prob_compound}.')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Filtering a SMACT search space using the oxidation states model\n",
+    "\n",
+    "Let's attempt to perform the first steps in a high-throughput compound design workflow which involves:\n",
+    "* Generating the search space using SMACT\n",
+    "* Filtering the search space using the oxidation states model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Composition generation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "tags": [
+     "hide-input",
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Get the cations that are in the probability table\n",
+    "cations = [species for species in ox_prob_finder.get_included_species()\n",
+    "           if '-' not in species]\n",
+    "\n",
+    "# Get the symbols of the d-block elements\n",
+    "d_block_symbols = smact.ordered_elements(\n",
+    "    21, 30) + smact.ordered_elements(39, 48) + smact.ordered_elements(71, 80)\n",
+    "\n",
+    "# This function will parse the species included in the probability table\n",
+    "\n",
+    "\n",
+    "def parse_species(species):\n",
+    "    match = re.match(r\"([A-Za-z]+)([0-9.]+)\", species)\n",
+    "    return match.group(1), int(match.group(2))\n",
+    "\n",
+    "\n",
+    "# Create a list of the d-block smact.Species objects from the d-block species in the table\n",
+    "allowed_dblock_species = [Species(parse_species(cation)[0], parse_species(\n",
+    "    cation)[1]) for cation in cations if parse_species(cation)[0] in d_block_symbols]\n",
+    "\n",
+    "# Get all the combinations of the d_block smact.Species objects\n",
+    "d_block_species_combos = combinations(allowed_dblock_species, 2)\n",
+    "\n",
+    "# Use this custom smact_filter function to generate the plausible compositions\n",
+    "\n",
+    "\n",
+    "def smact_filter(els):\n",
+    "    all_compounds = []\n",
+    "    halide_symbols = ['F', 'Cl', 'Br', 'I']\n",
+    "\n",
+    "    for halide in halide_symbols:\n",
+    "        elements = [e.symbol for e in els] + [halide]\n",
+    "\n",
+    "        halide_species = Species(halide, -1)\n",
+    "\n",
+    "        # Get the Pauling electronegativities\n",
+    "        paul_a, paul_b, paul_x = els[0].pauling_eneg, els[1].pauling_eneg, halide_species.pauling_eneg\n",
+    "        electronegativities = [paul_a, paul_b, paul_x]\n",
+    "\n",
+    "        # For each set of species (in oxidation states) apply both SMACT tests\n",
+    "        ox_a, ox_b = els[0].oxidation, els[1].oxidation\n",
+    "        ox_states = [ox_a, ox_b, -1]\n",
+    "        # Test for charge balance\n",
+    "        cn_e, cn_r = smact.neutral_ratios(ox_states, threshold=8)\n",
+    "        if cn_e:\n",
+    "            # Electronegativity test\n",
+    "            electroneg_OK = screening.pauling_test(\n",
+    "                ox_states, electronegativities)\n",
+    "            if electroneg_OK:\n",
+    "                compound = tuple([elements, (ox_a, ox_b, -1),\n",
+    "                                 cn_r[0], list(els)+[halide_species]])\n",
+    "                all_compounds.append(compound)\n",
+    "    return all_compounds\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-input",
+     "hide-output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of compositions: 14832\n",
+      "Each list entry looks like this:\n",
+      "  elements, oxidation states, stoichiometries\n",
+      "['Sc', 'Ni', 'F'] (3, 3, -1) (1, 1, 6)\n",
+      "['Sc', 'Ni', 'Cl'] (3, 3, -1) (1, 1, 6)\n",
+      "['Sc', 'Ni', 'Br'] (3, 3, -1) (1, 1, 6)\n",
+      "['Sc', 'Ni', 'I'] (3, 3, -1) (1, 1, 6)\n",
+      "['Sc', 'Ti', 'F'] (3, 4, -1) (1, 1, 7)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Use multiprocess to speed up the generation of the combinations\n",
+    "with multiprocess.Pool(3) as p:\n",
+    "    result = p.map(smact_filter, d_block_species_combos)\n",
+    "\n",
+    "flat_list = [item for sublist in result for item in sublist]\n",
+    "\n",
+    "# Here we grab the species string for each composition generated by smact\n",
+    "list_of_species = [species[3] for species in flat_list]\n",
+    "A_species = [\n",
+    "    f'{species[0].symbol}{species[0].oxidation}+' for species in list_of_species]\n",
+    "B_species = [\n",
+    "    f'{species[1].symbol}{species[1].oxidation}+' for species in list_of_species]\n",
+    "X_species = [f'{species[2].symbol}1-' for species in list_of_species]\n",
+    "\n",
+    "# Print out the first few entries from our search space\n",
+    "print(\"Number of compositions: {0}\".format(len(flat_list)))\n",
+    "print('Each list entry looks like this:\\n  elements, oxidation states, stoichiometries')\n",
+    "for i in flat_list[:5]:\n",
+    "    print(i[0], i[1], i[2])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "tags": [
+     "hide-input",
+     "hide-output"
+    ]
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Each list entry now looks like this: \n",
-      "Sc2TiF\n",
-      "ScTiF2\n",
-      "ScTiF3\n",
-      "ScTiF4\n",
-      "ScTiF5\n"
+      "ScNiF6\n",
+      "ScNiCl6\n",
+      "ScNiBr6\n",
+      "ScNiI6\n",
+      "ScTiF7\n"
      ]
     }
    ],
    "source": [
+    "# Get the formulas for the compositions\n",
     "from pymatgen.core import Composition\n",
+    "\n",
+    "\n",
     "def comp_maker(comp):\n",
     "    form = []\n",
     "    for el, ammt in zip(comp[0], comp[2]):\n",
@@ -199,43 +307,21 @@
     "    pmg_form = Composition(form).reduced_formula\n",
     "    return pmg_form\n",
     "\n",
-    "if __name__ == '__main__':  \n",
+    "\n",
+    "if __name__ == '__main__':\n",
     "    with multiprocess.Pool(3) as p:\n",
     "        pretty_formulas = p.map(comp_maker, flat_list)\n",
     "\n",
     "print('Each list entry now looks like this: ')\n",
     "for i in pretty_formulas[:5]:\n",
-    "    print(i)"
+    "    print(i)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below, we convert our list of elements, oxidation_states, stoichiometries into a list of lists of `smact.Species`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "def species_maker(comp):\n",
-    "    species_list=[]\n",
-    "    for el, ox in zip(comp[0], comp[1]):\n",
-    "        species_list.append(Species(el,oxidation=ox))\n",
-    "    return species_list\n",
-    "if __name__ == '__main__':  \n",
-    "    with multiprocess.Pool(3) as p:\n",
-    "        list_of_species = p.map(species_maker, flat_list)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "### Applying the oxidation states model\n",
     "The method `compound_probability` of the `Oxidation_state_probability_finder` class enables us to compute the likelihood of the metal species existing in the presence of particular anions. We will apply this to all the compounds generated by `smact`"
    ]
   },
@@ -245,15 +331,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "def compute_compound_probability(species_list):\n",
-    "    try:\n",
-    "       return ox_prob_finder.compound_probability(species_list)\n",
-    "    except NameError:\n",
-    "        return None\n",
-    "\n",
-    "# Compute the compound probabilities \n",
-    "compound_probabilities = [compute_compound_probability(spec) for spec in list_of_species]"
+    "# Compute the compound probabilities\n",
+    "compound_probabilities = [ox_prob_finder.compound_probability(\n",
+    "    spec) for spec in list_of_species]\n"
    ]
   },
   {
@@ -283,46 +363,64 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>formula_pretty</th>\n",
-       "      <th>prob</th>\n",
+       "      <th>A</th>\n",
+       "      <th>B</th>\n",
+       "      <th>X</th>\n",
+       "      <th>compound_probability</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>Sc2TiF</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>ScNiF6</td>\n",
+       "      <td>Sc3+</td>\n",
+       "      <td>Ni3+</td>\n",
+       "      <td>F1-</td>\n",
+       "      <td>0.567797</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>ScTiF2</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>ScNiCl6</td>\n",
+       "      <td>Sc3+</td>\n",
+       "      <td>Ni3+</td>\n",
+       "      <td>Cl1-</td>\n",
+       "      <td>0.318182</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>ScTiF3</td>\n",
-       "      <td>0.019608</td>\n",
+       "      <td>ScNiBr6</td>\n",
+       "      <td>Sc3+</td>\n",
+       "      <td>Ni3+</td>\n",
+       "      <td>Br1-</td>\n",
+       "      <td>0.250000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>ScTiF4</td>\n",
-       "      <td>0.176471</td>\n",
+       "      <td>ScNiI6</td>\n",
+       "      <td>Sc3+</td>\n",
+       "      <td>Ni3+</td>\n",
+       "      <td>I1-</td>\n",
+       "      <td>0.250000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>ScTiF5</td>\n",
-       "      <td>0.303922</td>\n",
+       "      <td>ScTiF7</td>\n",
+       "      <td>Sc3+</td>\n",
+       "      <td>Ti4+</td>\n",
+       "      <td>F1-</td>\n",
+       "      <td>0.803922</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "  formula_pretty      prob\n",
-       "0         Sc2TiF  0.000000\n",
-       "1         ScTiF2       NaN\n",
-       "2         ScTiF3  0.019608\n",
-       "3         ScTiF4  0.176471\n",
-       "4         ScTiF5  0.303922"
+       "  formula_pretty     A     B     X  compound_probability\n",
+       "0         ScNiF6  Sc3+  Ni3+   F1-              0.567797\n",
+       "1        ScNiCl6  Sc3+  Ni3+  Cl1-              0.318182\n",
+       "2        ScNiBr6  Sc3+  Ni3+  Br1-              0.250000\n",
+       "3         ScNiI6  Sc3+  Ni3+   I1-              0.250000\n",
+       "4         ScTiF7  Sc3+  Ti4+   F1-              0.803922"
       ]
      },
      "execution_count": 10,
@@ -332,10 +430,11 @@
    ],
    "source": [
     "# Create a dataframe\n",
-    "data = {'formula_pretty':pretty_formulas, 'prob': compound_probabilities}\n",
+    "data = {'formula_pretty': pretty_formulas, 'A': A_species, 'B': B_species,\n",
+    "        'X': X_species, 'compound_probability': compound_probabilities}\n",
     "\n",
     "df = pd.DataFrame(data)\n",
-    "df.head()"
+    "df.head()\n"
    ]
   },
   {
@@ -347,27 +446,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Our original smact query generated 38788 compositions. \n",
-      "We could compute compute compound probabilities for 20360 compositions. \n",
-      "Finally, there are 15884 compositions which have a non-zero compound probability.\n"
+      "The original smact search space produced 14832 compositons of which 12671 had a non-zero compound probability\n"
      ]
     }
    ],
    "source": [
-    "# Get the dataframe without the None probabilities\n",
-    "notNone_df=df.dropna(axis=0).reset_index(drop=True)\n",
+    "# Compute the number of non-zero compound probabilities\n",
     "\n",
-    "# Get the dataframe with the non-zero probabilities\n",
-    "nonZero_df= notNone_df.loc[notNone_df.prob>0].reset_index(drop=True)\n",
+    "# Convert the probability values from a pandas.Series object to a numpy array\n",
+    "probs = df.compound_probability.to_numpy()\n",
     "\n",
-    "print(f'Our original smact query generated {len(pretty_formulas)} compositions. \\nWe could compute compute compound probabilities for {notNone_df.shape[0]} compositions. \\nFinally, there are {nonZero_df.shape[0]} compositions which have a non-zero compound probability.')"
+    "# Create a numpy array of the non-zero probabilities\n",
+    "non_Zero_probs = probs[(probs > 0)]\n",
+    "\n",
+    "print(\n",
+    "    f'The original smact search space produced {len(probs)} compositons of which {len(non_Zero_probs)} had a non-zero compound probability')\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will know plot the number of compounds as a function of the probability threshold."
+    "#### Visualising the compound probabilities of the SMACT generated compositions.\n",
+    "We will now plot the number of compounds as a function of the probability threshold."
    ]
   },
   {
@@ -377,7 +478,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk0AAAGwCAYAAAC0HlECAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy89olMNAAAACXBIWXMAAA9hAAAPYQGoP6dpAABX4klEQVR4nO3de1hU5do/8O8gzAwHZxBSYBLJXdsDHjA1kTy02/FKaZZb24GakuIhD6nga+jPPGS7UEvdWoZamez3rSS36ZuHNPLEVkEUxSOiJnkIAbfIjJxB1u8P96wYh8MaXAwz8P1c11yXs9Yza+61KufuWfe6H4UgCAKIiIiIqFYOjR0AERERkT1g0kREREQkAZMmIiIiIgmYNBERERFJwKSJiIiISAImTUREREQSMGkiIiIiksCxsQNoKiorK5GVlYWWLVtCoVA0djhEREQkgSAIuHfvHnQ6HRwcap9LYtIkk6ysLPj6+jZ2GERERFQPN27cQNu2bWsdw6RJJi1btgTw4KJrNBrZjltUVoE+H+wDAKTMfwEuSv4jIyIikovBYICvr6/4O14b/gLLxHhLTqPRyJo0OZZVwEHlIh6bSRMREZH8pJTWsBCciIiISAImTUREREQSMGkiIiIikoBJExEREZEETJqIiIiIJGDSRERERCQBkyYiIiIiCZg0EREREUnQqElTYmIihg4dCp1OB4VCge3bt5uNSU9PxyuvvAKtVgtXV1c888wzuH79uri/pKQE06ZNg6enJ9zc3DBixAjk5OSYHOP69esYMmQIXFxc0KZNG8yZMwcVFRUmYw4ePIiePXtCpVLhqaeewqZNmxrilImIiMhONWrSVFhYiICAAKxdu7ba/b/88gv69++PTp064eDBgzhz5gwWLFgAtVotjomMjMSOHTuwZcsWHDp0CFlZWRg+fLi4//79+xgyZAjKyspw9OhRxMXFYdOmTVi4cKE4JjMzE0OGDMHzzz+PtLQ0zJo1CxMmTMDevXsb7uTrYCgpxy19cbX7bumLYSgpt3JEREREzZtCEAShsYMAHrQv37ZtG4YNGyZuCwsLg5OTE/7nf/6n2s/o9Xq0bt0a33zzDV577TUAwMWLF9G5c2ckJSWhb9+++PHHH/Hyyy8jKysLXl5eAIB169YhOjoat2/fhlKpRHR0NHbt2oVz586ZfHd+fj727NlT7XeXlpaitLRUfG9cu0av1z/yMiqGknKEb0zBnYIyfPXmM3hh5SEAwIUlIcgvKkfYhmR4uikRN74PNGqnR/ouIiKi5sxgMECr1Ur6/bbZmqbKykrs2rULHTp0QEhICNq0aYPAwECTW3ipqakoLy9HcHCwuK1Tp05o164dkpKSAABJSUno1q2bmDABQEhICAwGA86fPy+OqXoM4xjjMaoTExMDrVYrvnx9feU4bQBAYWkF7hSU4XpeEcK/ShG338ovQdiGZFzPK8KdgjIUllbUchQiIiKSk80mTbm5uSgoKMDSpUvx4osv4qeffsJf/vIXDB8+HIcOPZh5yc7OhlKphLu7u8lnvby8kJ2dLY6pmjAZ9xv31TbGYDCguLj6W2Tz5s2DXq8XXzdu3Hjkczby0Tpj86S+aOfhgpt3f//+8K9ScD2vCO08XLB5Ul/4aJ1l+04iIiKqnWNjB1CTyspKAMCrr76KyMhIAECPHj1w9OhRrFu3Ds8991xjhgeVSgWVStVgx9e5P0icXl+fJCZON+8WiwmTzp0JExERkTXZ7EzTY489BkdHR/j7+5ts79y5s/j0nLe3N8rKypCfn28yJicnB97e3uKYh5+mM76va4xGo4Gzc+MlJzp3Zywb0c1k26rQADFhYrE4ERGR9dhs0qRUKvHMM88gIyPDZPulS5fg5+cHAOjVqxecnJywb98+cX9GRgauX7+OoKAgAEBQUBDOnj2L3NxccUxCQgI0Go2YkAUFBZkcwzjGeIzGkpVfjOitZ022RcafRlZ+sVgsHro+GVn5xWafC12fjPCNKUyciIiIZNKoSVNBQQHS0tKQlpYG4MGj/2lpaeJM0pw5cxAfH4/PP/8cV65cwaeffoodO3Zg6tSpAACtVouIiAhERUXhwIEDSE1Nxbhx4xAUFIS+ffsCAAYNGgR/f3+MGTMGp0+fxt69e/Huu+9i2rRp4u21t956C1evXsU777yDixcv4rPPPsN3330n3hZsDFn5xQjbkGxS09S2lTOu5xUhbEMyruYWiMXiYRt+T5yMn2OxOBERkbwateXAwYMH8fzzz5ttDw8PF5tLbty4ETExMbh58yY6duyI9957D6+++qo4tqSkBLNnz8a3336L0tJShISE4LPPPhNvvQHAtWvXMGXKFBw8eBCurq4IDw/H0qVL4ej4e0nXwYMHERkZiQsXLqBt27ZYsGAB3nzzTcnnYskji3W5pX8wU3Q9rwhtWzmLidO+qOcwbtNxsRh8zcgemPFtmvh+VWgAIuNPmxSLs/aJiIioZpb8fttMnyZ7J2fSZEmfpoKSCnFmyYgJExERkTSW/H7b7NNzzZlG7YS48X1QWFoBrbNp80qduzPiJ/eFq8oRGrUTNGonrAoNwIjY33tKVS0WJyIiInnYbCF4c6dRO9XYh8lH6yx2As/KL0Zk/GmT/cZicSIiIpIPkyY7VrXou52HC7ZOCUI7Dxez4nAiIiJ6dEya7NQtvWnCtHlSX/Ty8xA7iRsTp5r6OBEREZFlmDTZKVeVIzzdlGZF38ZO4u08XODppoSrimVrREREcuAvqp2qWiz+cO1T1WJx4MGsVHX1Ubf0xWJBOREREdWOM012rK5icQDsGk5ERCQTJk1NWGFpBbuGExERyYRJUxPmo3U2KwxPvZZnVkBe02wVERER/Y5JUxNXtTD8el4RRsQmcZkVIiKiemDS1Azo3J2xKjTAZBu7hhMREVmGSVMzwK7hREREj45JUxPHruFERETyYNLUhLFrOBERkXyYNDVh7BpOREQkH/5aNmFSu4azIzgREVHdmDQ1cRq1U41JEfszERERScfbc0REREQSMGkiIiIikoBJE8FQUl7jE3S39MVc0JeIiAhMmpo9Q0k5wjemIHS9ec+mrPxihK5PRvjGFCZORETU7DFpauYKSytwp6DMrNll1aaYdwrKUFha0ciREhERNS4mTc2cj9bZrNll6rU8s6aYfNKOiIiaOyZNZNLs8npeEUbEJpkkTFzYl4iIiEkT/YfO3RmrQgNMtq0KDWDCRERE9B9MmgjAgxqmyPjTJtsi409zQV8iIqL/YNJEJkXf7TxcsHVKkEmNExMnIiIiJk3N3i19sVnRdy8/D7Pi8Jr6OBERETUXTJqaOVeVIzzdlGZF31WLwz3dlHBVcZlCIiJq3vhL2Mxp1E6IG98HhaUVZm0FdO7OiJ/cF64qxxoX/SUiImoumDQRNGqnGpOiqomUoaS82uQKeHCbj8kVERE1ZY16ey4xMRFDhw6FTqeDQqHA9u3baxz71ltvQaFQ4O9//7vJ9ry8PIwePRoajQbu7u6IiIhAQUGByZgzZ85gwIABUKvV8PX1xfLly82Ov2XLFnTq1AlqtRrdunXD7t275TjFJoPLrRARUXPXqElTYWEhAgICsHbt2lrHbdu2DcnJydDpdGb7Ro8ejfPnzyMhIQE7d+5EYmIiJk2aJO43GAwYNGgQ/Pz8kJqaio8++giLFy/Ghg0bxDFHjx7FyJEjERERgVOnTmHYsGEYNmwYzp07J9/J2jkut0JERM2dQhAEobGDAACFQoFt27Zh2LBhJtt/++03BAYGYu/evRgyZAhmzZqFWbNmAQDS09Ph7++P48ePo3fv3gCAPXv2YPDgwbh58yZ0Oh1iY2Mxf/58ZGdnQ6lUAgDmzp2L7du34+LFiwCA0NBQFBYWYufOneL39u3bFz169MC6deskxW8wGKDVaqHX66HRaB7xavyuqKwC/gv3AgAuLAmBi7Lx7qg+3JpgVWgAIuNPs3s4ERHZLUt+v2366bnKykqMGTMGc+bMQZcuXcz2JyUlwd3dXUyYACA4OBgODg44duyYOGbgwIFiwgQAISEhyMjIwN27d8UxwcHBJscOCQlBUlJSjbGVlpbCYDCYvJo6LrdCRETNmU0nTcuWLYOjoyNmzJhR7f7s7Gy0adPGZJujoyM8PDyQnZ0tjvHy8jIZY3xf1xjj/urExMRAq9WKL19fX8tOzk5xuRUiImqubDZpSk1NxerVq7Fp0yYoFIrGDsfMvHnzoNfrxdeNGzcaOySr4HIrRETUXNls0vSvf/0Lubm5aNeuHRwdHeHo6Ihr165h9uzZeOKJJwAA3t7eyM3NNflcRUUF8vLy4O3tLY7JyckxGWN8X9cY4/7qqFQqaDQak1dTx+VWiIioObPZpGnMmDE4c+YM0tLSxJdOp8OcOXOwd++DwuigoCDk5+cjNTVV/Nz+/ftRWVmJwMBAcUxiYiLKy39/FD4hIQEdO3ZEq1atxDH79u0z+f6EhAQEBQU19GnaDS63QkREzV2jNrcsKCjAlStXxPeZmZlIS0uDh4cH2rVrB09PT5PxTk5O8Pb2RseOHQEAnTt3xosvvoiJEydi3bp1KC8vx/Tp0xEWFia2Jxg1ahTee+89REREIDo6GufOncPq1auxatUq8bgzZ87Ec889hxUrVmDIkCHYvHkzTpw4YdKWoLkzLrcCoNrlVsI2JHO5FSIiatqERnTgwAEBgNkrPDy82vF+fn7CqlWrTLbduXNHGDlypODm5iZoNBph3Lhxwr1790zGnD59Wujfv7+gUqmExx9/XFi6dKnZsb/77juhQ4cOglKpFLp06SLs2rXLonPR6/UCAEGv11v0uboUlpYLftE7Bb/onUJhabmsx7aUvrhMyMovqnZfVn6RoC8us3JEREREj8aS32+b6dNk75pDnyYiIqKmpsn0aSIiIiKyFUyaiIiIiCRg0kREREQkAZMmIiIiIgmYNBERERFJwKSJiIiISAImTSQrQ0l5jV3Bb+mLYSgpr3YfERGRrWPSRLIxlJQjfGMKQtebr0OXlV+M0PXJCN+YwsSJiIjsEpMmkk1haQXuFJSZLeBbdaHfOwVlKCytaORIiYiILMekiWTjo3U2W8A39Vqe2UK/Plrnxg6ViIjIYkyaSFbGBXyNidOI2CSThMm40C8REZG9YdJEstO5O2NVaIDJtlWhAUyYiIjIrjFpItll5RcjMv60ybbI+NNmxeFERET2hEkTyapq0Xc7DxdsnRJkUuPExImIiOwVkyaSzS19sVnRdy8/D7Pi8Jr6OBEREdkyJk0kG1eVIzzdlGZF31WLwz3dlHBVOTZypERERJbjrxfJRqN2Qtz4PigsrTBrK6Bzd0b85L5wVTlCo3ZqpAiJiIjqj0kTyUqjdqoxKWJ/JiIisme8PUdEREQkAZMmIiIiIgmYNJHVGUrKa3yC7pa+mAv6EhGRTWLSRFZlKClH+MYUhK4379mUlV+M0PXJCN+YwsSJiIhsDpMmsqrC0grcKSgza3ZZtSnmnYIyFJZWNHKkREREppg0kVX5aJ3Nml2mXssza4rJJ+2IiMjWMGkiq6va7PJ6XhFGxCaZJExc2JeIiGwRkyZqFDp3Z6wKDTDZtio0gAkTERHZLCZN1Ciy8osRGX/aZFtk/Gku6EtERDaLSRNZXdWi73YeLtg6JcikxomJExER2SImTWRVt/TFZkXfvfw8zIrDa+rjRERE1FiYNJFVuaoc4emmNCv6rloc7ummhKuKyyISEZFt4S8TWZVG7YS48X1QWFph1lZA5+6M+Ml94apyrHHRXyIiosbSqDNNiYmJGDp0KHQ6HRQKBbZv3y7uKy8vR3R0NLp16wZXV1fodDqMHTsWWVlZJsfIy8vD6NGjodFo4O7ujoiICBQUFJiMOXPmDAYMGAC1Wg1fX18sX77cLJYtW7agU6dOUKvV6NatG3bv3t0g50wPEqea+jD5aJ2ZMBERkU1q1KSpsLAQAQEBWLt2rdm+oqIinDx5EgsWLMDJkyfx/fffIyMjA6+88orJuNGjR+P8+fNISEjAzp07kZiYiEmTJon7DQYDBg0aBD8/P6SmpuKjjz7C4sWLsWHDBnHM0aNHMXLkSERERODUqVMYNmwYhg0bhnPnzjXcyRMREZFdUQiCIDR2EACgUCiwbds2DBs2rMYxx48fR58+fXDt2jW0a9cO6enp8Pf3x/Hjx9G7d28AwJ49ezB48GDcvHkTOp0OsbGxmD9/PrKzs6FUKgEAc+fOxfbt23Hx4kUAQGhoKAoLC7Fz507xu/r27YsePXpg3bp1kuI3GAzQarXQ6/XQaDT1vArmisoq4L9wLwDgwpIQuCibxx1VQ0l5tbfwgAfF5LyFR0REcrDk99uuCsH1ej0UCgXc3d0BAElJSXB3dxcTJgAIDg6Gg4MDjh07Jo4ZOHCgmDABQEhICDIyMnD37l1xTHBwsMl3hYSEICkpqcZYSktLYTAYTF4kDy7qS0REtshukqaSkhJER0dj5MiRYiaYnZ2NNm3amIxzdHSEh4cHsrOzxTFeXl4mY4zv6xpj3F+dmJgYaLVa8eXr6/toJ0giLupLRES2yC6SpvLycrz++usQBAGxsbGNHQ4AYN68edDr9eLrxo0bjR1Sk8FFfYmIyBbZfIGMMWG6du0a9u/fb3K/0dvbG7m5uSbjKyoqkJeXB29vb3FMTk6OyRjj+7rGGPdXR6VSQaVS1f/EqFbGvk3GRGlE7INbpVzUl4iIGotNzzQZE6bLly/j559/hqenp8n+oKAg5OfnIzU1Vdy2f/9+VFZWIjAwUByTmJiI8vLf618SEhLQsWNHtGrVShyzb98+k2MnJCQgKCiooU6NJOCivkREZEsaNWkqKChAWloa0tLSAACZmZlIS0vD9evXUV5ejtdeew0nTpzA119/jfv37yM7OxvZ2dkoKysDAHTu3BkvvvgiJk6ciJSUFBw5cgTTp09HWFgYdDodAGDUqFFQKpWIiIjA+fPnER8fj9WrVyMqKkqMY+bMmdizZw9WrFiBixcvYvHixThx4gSmT59u9WtCv+OivkREZFOERnTgwAEBgNkrPDxcyMzMrHYfAOHAgQPiMe7cuSOMHDlScHNzEzQajTBu3Djh3r17Jt9z+vRpoX///oJKpRIef/xxYenSpWaxfPfdd0KHDh0EpVIpdOnSRdi1a5dF56LX6wUAgl6vr9e1qElhabngF71T8IveKRSWlst6bFv2290iYcCy/YJf9E5hwLL9wolf75i8/+1uUWOHSERETYAlv98206fJ3rFPk3xu6R+0Faha9K1zdzZ5eq6dhwviJ7MYnIiIHk2T7dNEzYPURX0rBQG39NXfqrulL2YfJyIiklXTn7YguyNlUd9KQcD0b07hTkGZ2dN0xhkpTzcl4sb3YedwIiKShcUzTXv27MHhw4fF92vXrkWPHj0watQoscM20aOqa1FfB4WCDTCJiMiqLE6a5syZIy4ZcvbsWcyePRuDBw9GZmamyRNpRA2JDTCJiMjaLL49l5mZCX9/fwDA1q1b8fLLL+PDDz/EyZMnMXjwYNkDJKoJG2ASEZE1WTzTpFQqUVRUBAD4+eefMWjQIACAh4cHF60lq2MDTCIishaLk6b+/fsjKioK77//PlJSUjBkyBAAwKVLl9C2bVvZAySqDRtgEhGRtVicNH366adwdHTEP//5T8TGxuLxxx8HAPz444948cUXZQ+QqCYP923aOiXIpMaJiRMREcmJzS1lwuaW1sUGmEREJAdLfr8l/QJbUqskZ8JAVBNjA0wA1TbANPZpclUxySQiInlI+kVxd3eHQqGQdMD79+8/UkBEUkhpgOmqcmRjSyIiko2kpOnAgQPin3/99VfMnTsXb775JoKCggAASUlJiIuLQ0xMTMNESVQNjdqpxqSIt+SIiEhukpKm5557TvzzkiVLsHLlSowcOVLc9sorr6Bbt27YsGEDwsPD5Y+SiIiIqJFZ/PRcUlISevfubba9d+/eSElJkSUoIiIiIltjcdLk6+uLzz//3Gz7F198AV9fX1mCIpKToaQct/TVtx+4pS+GoaTcyhEREZE9svjRolWrVmHEiBH48ccfERgYCABISUnB5cuXsXXrVtkDJHoUhpJyhG9MwZ2CMrOlVYztCTzdlIgb34dF40REVCuLZ5oGDx6My5cvY+jQocjLy0NeXh6GDh2KS5cuce05sjmFpRW4U1Bm1vCyaj+nOwVlKCytaORIiYjI1rG5pUzY3NJ2PdzwclVoACLjT5s1xiQiouZH9uaWD8vPz0dKSgpyc3NRWVlpsm/s2LH1OSRRg6na8PJ6XhFGxCYBABMmIiKyiMVJ044dOzB69GgUFBRAo9GYNL1UKBRMmsgm6dydsSo0QEyYAGBVaAATJiIikszimqbZs2dj/PjxKCgoQH5+Pu7evSu+8vLyGiJGokeWlV+MyPjTJtsi409zUV8iIpLM4qTpt99+w4wZM+Di4tIQ8RDJ7uGapq1TgtDOw8WsOJyIiKg2FidNISEhOHHiREPEQiS7W3rThGnzpL7o5eeBzZP6miROl3PusZcTERHVyuKapiFDhmDOnDm4cOECunXrBicn0942r7zyimzBET0qV5UjPN2UAGBS9F21ONzdxQmzt5xGflE5ezkREVGNLG454OBQ8+SUQqHA/fv3Hzkoe8SWA7bLUFKOwtKKahfxvaUvxr2SCkyIO2HWguDh23rxk/tyIWAioibGkt9vi2/PVVZW1vhqrgkT2TaN2qnGZMdH64wOXi3NbtelXsszu63HhImIqHmzOGkiaoqMt+uMidOI2CQ2vyQiIhMW3+tZsmRJrfsXLlxY72CIGhN7ORERUW0sTpq2bdtm8r68vByZmZlwdHTEk08+yaSJ7FZNvZw400REREA9kqZTp06ZbTMYDHjzzTfxl7/8RZagiKyttvXpwjYkM3EiIiJ5apo0Gg3ee+89LFiwQI7DEVmV1F5ONfVxIiKi5kG2QnC9Xg+9Xi/X4YisxtjL6eGi76rF4Z5uSriq2O6BiKg5szhpWrNmjclr9erVmDt3LkJDQ/HSSy9ZdKzExEQMHToUOp0OCoUC27dvN9kvCAIWLlwIHx8fODs7Izg4GJcvXzYZk5eXh9GjR0Oj0cDd3R0REREoKCgwGXPmzBkMGDAAarUavr6+WL58uVksW7ZsQadOnaBWq9GtWzfs3r3bonMh+6VROyFufB/ETza/Badzd0b85L5sbElERJbXNK1atcrkvYODA1q3bo3w8HDMmzfPomMVFhYiICAA48ePx/Dhw832L1++HGvWrEFcXBzat2+PBQsWICQkBBcuXIBarQYAjB49Grdu3UJCQgLKy8sxbtw4TJo0Cd988w2AB/VWgwYNQnBwMNatW4ezZ89i/PjxcHd3x6RJkwAAR48exciRIxETE4OXX34Z33zzDYYNG4aTJ0+ia9eull4iskMatVONSRH7MxEREQBAsBEAhG3btonvKysrBW9vb+Gjjz4St+Xn5wsqlUr49ttvBUEQhAsXLggAhOPHj4tjfvzxR0GhUAi//fabIAiC8NlnnwmtWrUSSktLxTHR0dFCx44dxfevv/66MGTIEJN4AgMDhcmTJ9cYb0lJiaDX68XXjRs3BACCXq+v3wWoQWFpueAXvVPwi94pFJaWy3pssoy+uEzIyi+qdl9WfpGgLy6zckRERPSo9Hq95N/vR6ppunnzJm7evClH7mYmMzMT2dnZCA4OFrdptVoEBgYiKelBH52kpCS4u7ujd+/e4pjg4GA4ODjg2LFj4piBAwdCqVSKY0JCQpCRkYG7d++KY6p+j3GM8XuqExMTA61WK758fX0f/aTJZhlKyhG+MQWh65ORlW9aEJ6VX4zQ9ckI35jChX2JiJqwei2jsmTJEmi1Wvj5+cHPzw/u7u54//33UVlZKVtg2dnZAAAvLy+T7V5eXuK+7OxstGnTxmS/o6MjPDw8TMZUd4yq31HTGOP+6sybN08sftfr9bhx44alp0h2pLC0AncKysQn6YyJU9VWBXcKylBYWtHIkRIRUUOxuKZp/vz5+PLLL7F06VL069cPAHD48GEsXrwYJSUl+OCDD2QP0hapVCqoVKrGDoOsxEf74Ek6Y4IUtiHZpJcT16cjImr6LE6a4uLi8MUXX+CVV14Rt3Xv3h2PP/44pk6dKlvS5O3tDQDIycmBj4+PuD0nJwc9evQQx+Tm5pp8rqKiAnl5eeLnvb29kZOTYzLG+L6uMcb9RMDvLQiMiZNxuRWuT0dE1DxYfHsuLy8PnTp1MtveqVMn5OXlyRIUALRv3x7e3t7Yt2+fuM1gMODYsWMICgoCAAQFBSE/Px+pqanimP3796OyshKBgYHimMTERJSX/15rkpCQgI4dO6JVq1bimKrfYxxj/B4iI+P6dFVxfToioubB4qQpICAAn376qdn2Tz/9FAEBAdV8omYFBQVIS0tDWloagAfF32lpabh+/ToUCgVmzZqFv/3tb/jhhx9w9uxZjB07FjqdDsOGDQMAdO7cGS+++CImTpyIlJQUHDlyBNOnT0dYWBh0Oh0AYNSoUVAqlYiIiMD58+cRHx+P1atXIyoqSoxj5syZ2LNnD1asWIGLFy9i8eLFOHHiBKZPn27p5aEmrqb16R4uDicioibI0kfzDh48KLi6ugqdO3cWxo8fL4wfP17o3Lmz4ObmJiQmJlp0rAMHDggAzF7h4eGCIDxoO7BgwQLBy8tLUKlUwgsvvCBkZGSYHOPOnTvCyJEjBTc3N0Gj0Qjjxo0T7t27ZzLm9OnTQv/+/QWVSiU8/vjjwtKlS81i+e6774QOHToISqVS6NKli7Br1y6LzsWSRxYtwZYDtuO3u0XCgGX7Bb/oncKAZfuFE7/eMXn/293q2xEQEZHtsuT3WyEIgmBpopWVlYW1a9fi4sWLAB7M+EydOlWc3WmODAYDtFot9Ho9NBqNbMctKquA/8K9AIALS0LgouRSHo3hlv5BW4GqRd86d2ezhX6/DO8NN7VjtQXht/TFcFU5srM4EZENseT3u16/wDqdrtk8JUcE/L4+HYBq16cL25AMdxcnzN5yGvlF5WaF4cbkytNNySVZiIjsVL2Sprt37+LLL79Eeno6AMDf3x/jxo2Dh4eHrMER2Qrj+nSFpRVms0jG9enulVRgQtwJsSVBdbNRwIOeT0yaiIjsj8WF4ImJiXjiiSewZs0a3L17F3fv3sWaNWvQvn17JCYmNkSMRDZBo3aqsQ+Tj9YZHbxaYvOkvmjn4SImTqnX8kxu37GXExGR/bK4pqlbt24ICgpCbGwsWrRoAQC4f/8+pk6diqNHj+Ls2bMNEqitY00TGT08swSwlxMRka2y5Pfb4pmmK1euYPbs2WLCBAAtWrRAVFQUrly5Ynm0RE0MezkRETVNFidNPXv2FGuZqkpPT7e4TxNRU8ReTkRETZPF93pmzJiBmTNn4sqVK+jbty8AIDk5GWvXrsXSpUtx5swZcWz37t3li5TIDjzcgqDq+nRVi8OJiMj+WFzT5OBQ++SUQqGAIAhQKBS4f//+IwVnT1jTRFJ7OcVPZjE4EZGtaNA+TZmZmfUOjKgpk9LLydNNCVcVE18iIntk8d/efn5+DREHkd2T0suJHcGJiOxXvf6XNysrC4cPH0Zubi4qKytN9s2YMUOWwIjskUbtVGNSxFtyRET2zeKkadOmTZg8eTKUSiU8PT2hUCjEfQqFgkkTERERNUkWJ00LFizAwoULMW/evDqLwomIiIiaCouznqKiIoSFhTFhIiIiombF4swnIiICW7ZsaYhYiIiIiGyWxbfnYmJi8PLLL2PPnj3o1q0bnJxMi15XrlwpW3BETZGhpLzaJ+yAB72e+IQdEZFtqlfStHfvXnTs2BEAzArBiahmhpJyhG9MwZ2CMrPu4MYmmJ5uSsSN78PEiYjIxlicNK1YsQIbN27Em2++2QDhEDVthaUVuFNQZrasStWu4cZxTJqIiGyLxTVNKpUK/fr1a4hYiJo8H+2D7uDtPFzExCn1Wp7JMiubJ3GZFSIiW2Rx0jRz5kx88sknDRELUbNgXFbFmDiNiE0yW6+OiIhsj8W351JSUrB//37s3LkTXbp0MSsE//7772ULjqip0rk7Y1VoAEbEJonbVoUGMGEiIrJhFidN7u7uGD58eEPEQtRsZOUXIzL+tMm2yPjTnGkiIrJhFidNX331VUPEQdRsVC36bufhglWhAYiMP21WHE5ERLal3m29b9++jcOHD+Pw4cO4ffu2nDERNVm39MVmRd+9/DzMisNv6YsbO1QiInqIxUlTYWEhxo8fDx8fHwwcOBADBw6ETqdDREQEioqKGiJGoibDVeUITzelWdF31eJwTzclXFUWTwITEVEDszhpioqKwqFDh7Bjxw7k5+cjPz8f//d//4dDhw5h9uzZDREjUZOhUTshbnwfxE82vwWnc3dG/OS+bGxJRGSjLP7f2a1bt+Kf//wn/vSnP4nbBg8eDGdnZ7z++uuIjY2VMz6iJkejdqoxKWJ/JiIi22XxTFNRURG8vLzMtrdp04a354hkZCgpr7G26Za+GIaScitHRETUvFmcNAUFBWHRokUoKSkRtxUXF+O9995DUFCQrMERNVfGNepC1ycjK980ccrKL0bo+mSEb0xh4kREZEUW355bvXo1QkJC0LZtWwQEBAAATp8+DbVajb1798oeIFFzxDXqiIhsj8UzTV27dsXly5cRExODHj16oEePHli6dCkuX76MLl26NESMRM0O16gjIrI99erT5OLigokTJ2LFihVYsWIFJkyYAGdn+f/yvn//PhYsWID27dvD2dkZTz75JN5//30IgiCOEQQBCxcuhI+PD5ydnREcHIzLly+bHCcvLw+jR4+GRqOBu7s7IiIiUFBQYDLmzJkzGDBgANRqNXx9fbF8+XLZz4fIElyjjojItlicNMXExGDjxo1m2zdu3Ihly5bJEpTRsmXLEBsbi08//RTp6elYtmwZli9fbrJg8PLly7FmzRqsW7cOx44dg6urK0JCQkxqrkaPHo3z588jISEBO3fuRGJiIiZNmiTuNxgMGDRoEPz8/JCamoqPPvoIixcvxoYNG2Q9HyJLGdeoq4pr1BERNQ6Lk6b169ejU6dOZtu7dOmCdevWyRKU0dGjR/Hqq69iyJAheOKJJ/Daa69h0KBBSElJAfBglunvf/873n33Xbz66qvo3r07/vGPfyArKwvbt28HAKSnp2PPnj344osvEBgYiP79++OTTz7B5s2bkZWVBQD4+uuvUVZWho0bN6JLly4ICwvDjBkzsHLlSlnPh8hSNa1R93BxOBERNTyLk6bs7Gz4+PiYbW/dujVu3bolS1BGzz77LPbt24dLly4BeFBwfvjwYbz00ksAgMzMTGRnZyM4OFj8jFarRWBgIJKSHqwen5SUBHd3d/Tu3VscExwcDAcHBxw7dkwcM3DgQCiVSnFMSEgIMjIycPfu3WpjKy0thcFgMHkRyenhNeq2TgkyqXFi4kREZF0WJ02+vr44cuSI2fYjR45Ap9PJEpTR3LlzERYWhk6dOsHJyQlPP/00Zs2ahdGjRwN4kMABMOsb5eXlJe7Lzs5GmzZtTPY7OjrCw8PDZEx1x6j6HQ+LiYmBVqsVX76+vo94tkS/4xp1RES2x+KkaeLEiZg1axa++uorXLt2DdeuXcPGjRsRGRmJiRMnyhrcd999h6+//hrffPMNTp48ibi4OHz88ceIi4uT9XvqY968edDr9eLrxo0bjR0SNSFS16irFAQ2wCQishKL+zTNmTMHd+7cwdSpU1FWVgYAUKvViI6Oxrx582QNbs6cOeJsEwB069YN165dQ0xMDMLDw+Ht7Q0AyMnJMbllmJOTgx49egAAvL29kZuba3LciooK5OXliZ/39vZGTk6OyRjje+OYh6lUKqhUqkc/SaJqGNeoKyytMGsrYFyjrlIQMP2bU7hTUGb2NJ3x1p6nm5Jr2RERycTimSaFQoFly5bh9u3bSE5OxunTp5GXl4eFCxfKHlxRUREcHExDbNGiBSorKwEA7du3h7e3N/bt2yfuNxgMOHbsmNidPCgoCPn5+UhNTRXH7N+/H5WVlQgMDBTHJCYmorz89/8rT0hIQMeOHdGqVSvZz4tICo3aqcY+TD5aZzgoFCYNMI01TlVroe4UlKGwtMKaYRMRNVn16tMEAG5ubnjmmWfQtWvXBptxGTp0KD744APs2rULv/76K7Zt24aVK1fiL3/5C4AHCdysWbPwt7/9DT/88APOnj2LsWPHQqfTYdiwYQCAzp0748UXX8TEiRORkpKCI0eOYPr06QgLCxNrsEaNGgWlUomIiAicP38e8fHxWL16NaKiohrkvIjkwAaYRETWpRCqdoq0Mffu3cOCBQuwbds25ObmQqfTYeTIkVi4cKH4pJsgCFi0aBE2bNiA/Px89O/fH5999hk6dOggHicvLw/Tp0/Hjh074ODggBEjRmDNmjVwc3MTx5w5cwbTpk3D8ePH8dhjj+Htt99GdHS05FgNBgO0Wi30ej00Go1s16CorAL+Cx8sT3NhSQhclBbfUaUm7uGlVQCwASYRkUSW/H7bdNJkT5g0UWNKvZaHEbFJ4vutU4LQy8+jESMiIrIPlvx+1/v2HBHZhroaYBpKyvmEHRGRDCQlTT179hSbPC5ZsgRFRUV1fIKIrKGuBpiXsu8hfGMKQtebN8PMyi9G6PpkhG9MYeJERCSBpKQpPT0dhYWFAID33nvPbLFbIrI+KQ0w39yUglxDCZ+wIyKSgaQCmR49emDcuHHo378/BEHAxx9/bFJEXVVDtB4gInPGBpgAqm2AaezTtGxEd0yIOyEmTqtCAxAZf5pP2BERWUhSIXhGRgYWLVqEX375BSdPnoS/vz8cHc3zLYVCgZMnTzZIoLaOheDUGAwl5dU2wAQezES5qhyhUTvxCTsiohpY8vst6Re4Y8eO2Lx5MwDAwcEB+/btM1vPjYisT6N2qrHbd9VESufujFWhASZP2K0KDWDCRERkAYufnqusrGTCRGRn6nrCjoiI6lavlgO//PIL3n77bQQHByM4OBgzZszAL7/8IndsRCSDup6wY+JERCSNxUnT3r174e/vj5SUFHTv3h3du3fHsWPH0KVLFyQkJDREjERUT1KesAvbkIzLOffYy4mIqA4WVxXPnTsXkZGRWLp0qdn26Oho/Nd//ZdswRHRo5HyhJ27ixNmbzmN/KJys8Jw4yyVp5sSceP71Fg/RUTUHFg805Seno6IiAiz7ePHj8eFCxdkCYqI5KFROyFufB/ETzZ/Sk7n7oz4yX3x8V8DkF9Uzl5ORER1sDhpat26NdLS0sy2p6WlsUCcyAZp1E419mHy0Tqjg1dLs9t1qdfyzG7rsZcTETV3Ft+emzhxIiZNmoSrV6/i2WefBQAcOXIEy5YtQ1RUlOwBElHDq3q77npekdiagL2ciIh+Z3HStGDBArRs2RIrVqzAvHnzAAA6nQ6LFy/GjBkzZA+QiKyDvZyIiGpn8e05hUKByMhI3Lx5E3q9Hnq9Hjdv3sTMmTOhUCgaIkYisgL2ciIiql29+jQZtWzZEi1btpQrFiJqJFJ6ORlKytmWgIiaNS5kRtTMVdfL6eEap9fXJcHdxQmGkgq2JSCiZuuRZpqIyP4Zezk9XPRtTJzaebhA6+KE/GK2JSCi5o0zTUTNnLGXU2FphVlbAWMvJ1eVIwpKKsQEKWxDMlaFBiAy/jTbEhBRs2HRTFN5eTleeOEFXL58uaHiIaJGUFcvJ43ayWTmydiW4OFbekRETZlFSZOTkxPOnDnTULEQkY0ztiWo6uG2BCwYJ6KmyuKapjfeeANffvllQ8RCRDaurrYEhpJyhG9MQej6ZLNWBVn5xQhdn4zwjSlMnIjILllc01RRUYGNGzfi559/Rq9eveDq6mqyf+XKlbIFR0S24+G2BFVrmsI2JGPzpL5QKIA7BWUm23TuziafBYDC0go+ZUdEdsfimaZz586hZ8+eaNmyJS5duoRTp06Jr+rWpCMi+1ddW4Jefh5ma9YB4Dp2RNRkWTzTdODAgYaIg4hsmLEtAYBq2xIY+zS5qhyhUTtxHTsiapLq3XLgypUr+OWXXzBw4EA4OztDEAQuo0LUREltS2C85cZ17IioKbL49tydO3fwwgsvoEOHDhg8eDBu3boFAIiIiMDs2bNlD5CIbIOUtgRGUgrG+YQdEdkbi5OmyMhIODk54fr163BxcRG3h4aGYs+ePbIGR0T2p6517C5l3+MTdkRklyxOmn766ScsW7YMbdu2Ndn+xz/+EdeuXZMtMCKyP1IKxt/clIJcQwmXZCEiu2Nx0lRYWGgyw2SUl5cHlUolS1BEZJ+krGPnpVHjq3F9+IQdEdkdi5OmAQMG4B//+If4XqFQoLKyEsuXL8fzzz8va3BEZF+MBePxk82fkjMWjMeN74MOXi25JAsR2R2Lk6bly5djw4YNeOmll1BWVoZ33nkHXbt2RWJiIpYtWyZ7gL/99hveeOMNeHp6wtnZGd26dcOJEyfE/YIgYOHChfDx8YGzszOCg4PN1sbLy8vD6NGjodFo4O7ujoiICBQUFJiMOXPmDAYMGAC1Wg1fX18sX75c9nMhag6kFoxLWZKFiMiWWJw0de3aFZcuXUL//v3x6quvorCwEMOHD8epU6fw5JNPyhrc3bt30a9fPzg5OeHHH3/EhQsXsGLFCrRq1Uocs3z5cqxZswbr1q3DsWPH4OrqipCQEJSUlIhjRo8ejfPnzyMhIQE7d+5EYmIiJk2aJO43GAwYNGgQ/Pz8kJqaio8++giLFy/Ghg0bZD0fIvpdXU/YERHZGoUgCEJjB1GTuXPn4siRI/jXv/5V7X5BEKDT6TB79mz893//NwBAr9fDy8sLmzZtQlhYGNLT0+Hv74/jx4+jd+/eAIA9e/Zg8ODBuHnzJnQ6HWJjYzF//nxkZ2dDqVSK3719+3ZcvHhRUqwGgwFarRZ6vR4ajUaGs3+gqKwC/gv3AgAuLAmBi7LerbWIbEZtS7IYb9G5qR2r7QsFPCg4r9oXioioviz5/bZ4pgl4MAP08ccfIyIiAhEREVixYgXy8vLqFWxtfvjhB/Tu3Rt//etf0aZNGzz99NP4/PPPxf2ZmZnIzs5GcHCwuE2r1SIwMBBJSQ+a6iUlJcHd3V1MmAAgODgYDg4OOHbsmDhm4MCBYsIEACEhIcjIyMDdu3erja20tBQGg8HkRUR1k/KE3evrkjBqQzLbEhCRTbE4aUpMTMQTTzyBNWvW4O7du7h79y7WrFmD9u3bIzExUdbgrl69itjYWPzxj3/E3r17MWXKFMyYMQNxcXEAgOzsbACAl5eXyee8vLzEfdnZ2WjTpo3JfkdHR3h4eJiMqe4YVb/jYTExMdBqteLL19f3Ec+WqHmQ8oSd1sUJ+cXlbEtARDbF4ns906ZNQ2hoKGJjY9GiRQsAwP379zF16lRMmzYNZ8+elS24yspK9O7dGx9++CEA4Omnn8a5c+ewbt06hIeHy/Y99TFv3jxERUWJ7w0GAxMnIgmkLslSUFIhJkhhG5KrvYXHtgREZE0WzzRduXIFs2fPFhMmAGjRogWioqJw5coVWYPz8fGBv7+/ybbOnTvj+vXrAABvb28AQE5OjsmYnJwccZ+3tzdyc3NN9ldUVCAvL89kTHXHqPodD1OpVNBoNCYvIpJGyhN2VWee2JaAiGyBxUlTz549kZ6ebrY9PT0dAQEB1Xyi/vr164eMjAyTbZcuXYKfnx8AoH379vD29sa+ffvE/QaDAceOHUNQUBAAICgoCPn5+UhNTRXH7N+/H5WVlQgMDBTHJCYmorz89/qIhIQEdOzY0eRJPSKyLrYlICJbIun23JkzZ8Q/z5gxAzNnzsSVK1fQt29fAEBycjLWrl2LpUuXyhpcZGQknn32WXz44Yd4/fXXkZKSgg0bNoitABQKBWbNmoW//e1v+OMf/4j27dtjwYIF0Ol0GDZsGIAHM1MvvvgiJk6ciHXr1qG8vBzTp09HWFgYdDodAGDUqFF47733EBERgejoaJw7dw6rV6/GqlWrZD0fIrJMTW0JjDNNhpJyPmFHRFYjqeWAg4MDFAoF6hqqUChw//592YIDgJ07d2LevHm4fPky2rdvj6ioKEycOFHcLwgCFi1ahA0bNiA/Px/9+/fHZ599hg4dOohj8vLyMH36dOzYsQMODg4YMWIE1qxZAzc3N3HMmTNnMG3aNBw/fhyPPfYY3n77bURHR0uOky0HiORVV1uCL8b2RvT3Z3CnoMzsdp3xs55uSsSN78PEiYhqZMnvt6SkyZKFeI23zpobJk1E8rmlf9BW4OEapqqJlM5dDQWA3/JLahzTzsMF8ZNZME5ENbPk91vSL3BzTYSIqHEY2xIAqLYtgXEWadmI7pgQd4JP2BGRVdSrI3hWVhYOHz6M3NxcVFZWmuybMWOGbMHZE840EclLar1S1ZklIz5hR0RSyT7TVNWmTZswefJkKJVKeHp6QqFQiPsUCkWzTZqISF4atVONtUhVEynjE3YjYpPEbVWfsGOxOBHJxeKWAwsWLMDChQuh1+vx66+/IjMzU3xdvXq1IWIkIqpRbQv/GkrKEb4xhcuxEJEsLE6aioqKEBYWBgeHei1bR0Qkm4eLvrdOCRKbYYZtSMbV3ALcKSjjcixEJAuLM5+IiAhs2bKlIWIhIpJMysK/MzanYc3IHiaJVOq1PLPPsViciKSwuKYpJiYGL7/8Mvbs2YNu3brBycm0FmDlypWyBUdEVBOpT9j9obWb+N64HAvAYnEisly9kqa9e/eiY8eOAGBWCE5EZA1SF/41FpTXVixORCSFxUnTihUrsHHjRrz55psNEA4RkXRSn7CrazkWIiIpLK5pUqlU6NevX0PEQkQku7qKxR9+qo6IqCYWJ00zZ87EJ5980hCxEBHJSkqxeNiGZNzSP2hPcEtffQJl3E9EzZvFt+dSUlKwf/9+7Ny5E126dDErBP/+++9lC46I6FFILRavFASEb0zh4r9EVCuLkyZ3d3cMHz68IWIhIpKV1GLxwtIKk35O1S3+CwCFpRVMmoiaMYuTpq+++qoh4iAiahBSisU1aieTtgRc/JeIqsO23kRE+P2WnbHWaURskknCxKfsiMjimab27dvX2o+J688Rkb2qa/FfImreLE6aZs2aZfK+vLwcp06dwp49ezBnzhy54iIisjr2cyKi2licNM2cObPa7WvXrsWJEyceOSAiosbwcD+nqjVNVYvDiaj5kq2m6aWXXsLWrVvlOhwRkdVY0s+JiJov2ZKmf/7zn/Dw8JDrcEREVmPs5/Rw0XfV4nBPNyVcVRZPzhNRE2Lx3wBPP/20SSG4IAjIzs7G7du38dlnn8kaHBGRNViy+C8RNV8WJ03Dhg0zee/g4IDWrVvjT3/6Ezp16iRXXEREViV18V8iar4sTpoWLVrUEHEQERER2TQ2tyQiIiKSQPJMk4ODQ61NLQFAoVCgoqLikYMiIiIisjWSk6Zt27bVuC8pKQlr1qxBZWWlLEERERER2RrJSdOrr75qti0jIwNz587Fjh07MHr0aCxZskTW4IiIiIhsRb1qmrKysjBx4kR069YNFRUVSEtLQ1xcHPz8/OSOj4iIiMgmWJQ06fV6REdH46mnnsL58+exb98+7NixA127dm2o+IiIiIhsguTbc8uXL8eyZcvg7e2Nb7/9ttrbdURERERNleSkae7cuXB2dsZTTz2FuLg4xMXFVTvu+++/ly04IiIiIlshOWkaO3ZsnS0HiIiIiJoqyUnTpk2bGjAMaZYuXYp58+Zh5syZ+Pvf/w4AKCkpwezZs7F582aUlpYiJCQEn332Gby8vMTPXb9+HVOmTMGBAwfg5uaG8PBwxMTEwNHx99M/ePAgoqKicP78efj6+uLdd9/Fm2++aeUzJCIiIltlNx3Bjx8/jvXr16N79+4m2yMjI7Fjxw5s2bIFhw4dQlZWFoYPHy7uv3//PoYMGYKysjIcPXoUcXFx2LRpExYuXCiOyczMxJAhQ/D8888jLS0Ns2bNwoQJE7B3716rnR8RERHZNrtImgoKCjB69Gh8/vnnaNWqlbhdr9fjyy+/xMqVK/HnP/8ZvXr1wldffYWjR48iOTkZAPDTTz/hwoUL+N///V/06NEDL730Et5//32sXbsWZWVlAIB169ahffv2WLFiBTp37ozp06fjtddew6pVq2qMqbS0FAaDweRFRERETZddJE3Tpk3DkCFDEBwcbLI9NTUV5eXlJts7deqEdu3aISkpCcCDbuXdunUzuV0XEhICg8GA8+fPi2MePnZISIh4jOrExMRAq9WKL19f30c+TyIiIrJdNp80bd68GSdPnkRMTIzZvuzsbCiVSri7u5ts9/LyQnZ2tjimasJk3G/cV9sYg8GA4uLiauOaN28e9Hq9+Lpx40a9zo+IiIjsg+RC8MZw48YNzJw5EwkJCVCr1Y0djgmVSgWVStXYYRAREZGV2PRMU2pqKnJzc9GzZ084OjrC0dERhw4dwpo1a+Do6AgvLy+UlZUhPz/f5HM5OTnw9vYGAHh7eyMnJ8dsv3FfbWM0Gg2cnZ0b6OyIyN4YSspxS1/97PMtfTEMJeVWjoiIrMmmk6YXXngBZ8+eRVpamvjq3bs3Ro8eLf7ZyckJ+/btEz+TkZGB69evIygoCAAQFBSEs2fPIjc3VxyTkJAAjUYDf39/cUzVYxjHGI9BRGQoKUf4xhSErk9GVr5p4pSVX4zQ9ckI35jCxImoCbPp23MtW7Y0W9fO1dUVnp6e4vaIiAhERUXBw8MDGo0Gb7/9NoKCgtC3b18AwKBBg+Dv748xY8Zg+fLlyM7Oxrvvvotp06aJt9feeustfPrpp3jnnXcwfvx47N+/H9999x127dpl3RMmIptVWFqBOwVluJ5XhLANydg8qS907s7Iyi9G2IZkXM8rEsdp1E6NHC0RNQSbnmmSYtWqVXj55ZcxYsQIDBw4EN7e3iZLubRo0QI7d+5EixYtEBQUhDfeeANjx47FkiVLxDHt27fHrl27kJCQgICAAKxYsQJffPEFQkJCGuOUiMgG+WidsXlSX7TzcBETp9RreWLC1M7DBZsn9YWPlrf0iZoqhSAIQmMH0RQYDAZotVro9XpoNBrZjltUVgH/hQ+abF5YEgIXpU1PDhI1eQ/PLAEQEyadOxMmIntjye+33c80ERFZk87dGatCA0y2rQoNEBMmFosTNV1MmoiILJCVX4zI+NMm2yLjTyMrv5jF4kRNHJMmIiKJqt6aa+fhgq1TgkxqnK7mFpgUixsTp6qfu1NQhsLSikY+EyKqDyZNREQS3NIXmxV99/LzMCkOn7E5DWtG9mCxOFETxaSJiEgCV5UjPN2UZkXfOvffn6rzdFPiD63dTBKpEbFJJgkTi8WJ7BcfxSIikkCjdkLc+D4oLK0wmynSuTsjfnJfuKocoVE7QaN2wqrQAIyI/X3R76rF4kRknzjTREQkkUbtVOOtNR+ts9jUsrZicYBP2BHZKyZNREQyqqtY/FL2PT5hR2SnmDQREclESrH4m5tSkGso4RN2RHaISRMRkUykFIt7adT4alwfPmFHZIe4jIpMuIwKEQEP6pWqKxYHHsxEGYvFuRwLkW3gMipERI1EarF4XcuxEJHtYdJERNQI+IQdkf1h0kREZGV8wo7IPjFpIiKyIj5hR2S/mDQREVkRn7Ajsl98ek4mfHqOiKTiE3ZEtoNPzxER2TA5n7BjwTiR9TBpIiKyUVKesGPBOJH1MGkiIrJBdT1hl5VfjMLSCtwpKGPBOJGVMGkiIrIxUp6wC9uQDABm21gwTtRwmDQREdkYKU/Yebop4apyNNl2Pa8II2KTTBImFowTyYePYhER2RiN2glx4/tU+4Sdzt0Z8ZP7ik/YGbetCg3AiNgkcVzVgnGpT+sRUe0400REZIOkPmEH1F4wzmJxIvkwaSIismN1FYxfzS1gsTiRTJg0ERHZKSkF4zM2p2HNyB51Fou7qhzZ74moDkyaiIjslNSC8T+0dqu1WNxN7chbeEQSMGkiIrJTxoLx+MnmT8kZC8bjxveBRu1Ua3dx9nsikoZJExGRHZNaMF5bsbiP1pn9nogkYNJERNTESekuLqXfE9e5o+aOSRMRURMmtbv4LX1xrbfw2LqAyA6SppiYGDzzzDNo2bIl2rRpg2HDhiEjI8NkTElJCaZNmwZPT0+4ublhxIgRyMnJMRlz/fp1DBkyBC4uLmjTpg3mzJmDigrT+/MHDx5Ez549oVKp8NRTT2HTpk0NfXpERA3Kku7itd3CY90TkR0kTYcOHcK0adOQnJyMhIQElJeXY9CgQSgsLBTHREZGYseOHdiyZQsOHTqErKwsDB8+XNx///59DBkyBGVlZTh69Cji4uKwadMmLFy4UByTmZmJIUOG4Pnnn0daWhpmzZqFCRMmYO/evVY9XyIiOUktFi8oqaj1Fp4gSFvnjq0LqClTCIIgNHYQlrh9+zbatGmDQ4cOYeDAgdDr9WjdujW++eYbvPbaawCAixcvonPnzkhKSkLfvn3x448/4uWXX0ZWVha8vLwAAOvWrUN0dDRu374NpVKJ6Oho7Nq1C+fOnRO/KywsDPn5+dizZ0+dcRkMBmi1Wuj1emg0GtnOt6isAv4LHyRuF5aEwEXJlW+ISF639A9urz1cw/RwLVT85L4QBIjbjB5uXXCnoMxs3TvjsTzdlIgb3wcAuLQL2QRLfr9tfqbpYXq9HgDg4eEBAEhNTUV5eTmCg4PFMZ06dUK7du2QlPRgHaakpCR069ZNTJgAICQkBAaDAefPnxfHVD2GcYzxGA8rLS2FwWAweRER2SNLFwh+1NYFOfoS1keRXbKrpKmyshKzZs1Cv3790LVrVwBAdnY2lEol3N3dTcZ6eXkhOztbHFM1YTLuN+6rbYzBYEBxsflUc0xMDLRarfjy9fWV5RyJiKzNkn5PcrQucFM7Sk6ueKuPbIldJU3Tpk3DuXPnsHnz5sYOBfPmzYNerxdfN27caOyQiIjqTUq/J7laF0hJrr4Y2xvvbD3D2SiyKXaTNE2fPh07d+7EgQMH0LZtW3G7t7c3ysrKkJ+fbzI+JycH3t7e4piHn6Yzvq9rjEajgbOz+V8kKpUKGo3G5EVE1FTJ1brAqK7kqqWztNkoPq1H1mTzSZMgCJg+fTq2bduG/fv3o3379ib7e/XqBScnJ+zbt0/clpGRgevXryMoKAgAEBQUhLNnzyI3N1cck5CQAI1GA39/f3FM1WMYxxiPQUTUnMnVuqCq2pIrqbf6+LQeWZPNPz03depUfPPNN/i///s/dOzYUdyu1WrFGaApU6Zg9+7d2LRpEzQaDd5++20AwNGjRwE8aDnQo0cP6HQ6LF++HNnZ2RgzZgwmTJiADz/8EMCDlgNdu3bFtGnTMH78eOzfvx8zZszArl27EBISUmecfHqOiJo6Q0l5nU+8Pdy6YFVoACLjT5vdogNMZ42MLBljydN6fBKPatKknp6LjY2FXq/Hn/70J/j4+Iiv+Ph4ccyqVavw8ssvY8SIERg4cCC8vb3x/fffi/tbtGiBnTt3okWLFggKCsIbb7yBsWPHYsmSJeKY9u3bY9euXUhISEBAQABWrFiBL774QlLCRETUHNRV91RYWiH5Fp6U+iig9tkoNtwka7P5mSZ7wZkmImrujEut1DXzs2xEd0yIO/HIfaGq+0xtM1tE1WlSM01ERGQfpLYu8NaqJdVH3aujSzkXGiZr40yTTDjTREQkXV31UfdKKiTPRvlonZF6LQ8jYn9vRrx1ShB6+XlInv1i3VPzxZkmIiKyaXXVR0mdjZJzoWHOSFFdmDQREZHNaYyFhqUs7fJbfhETq2aMSRMREdkkuZ7WUyhQZ92TlBmp24ZSTP5HKruUN2NMmoiIyC7JtdAwAEnNND8d9TQMJRVcM68ZYyG4TFgITkRkfVIabj68bp5RdS0J6hpXV4uDL8b2RvT3Z+osPP901NNwUCjqjJsaHgvBiYioWZBroWGjumak5FgzT+ptPtZP2R4mTURE1GRZstAwAEnr5j3qmnlSbvOxfso2MWkiIqImy9KFhqXMSNWVWNU1G9WjXSvZ6qfYKsG6WNMkE9Y0ERHZJil1T4WlFQhdn2z2VN3DidSakT0w49s0Scu21NRw0+hR66csWbRYSg0VAEn1YU0Na5qIiIj+Q0rdk5QZqZZqR0z/5pTkBYkf5Tbfw9/d0K0S3vjiGN744hjrrOrApImIiJo9Kc00N4zthdYtVbKsmQc8ev0UIF+rhH8XlOJOQSkL2OvA23My4e05IqKmT64186Te5rNWq4TNk/oCQK1j1oT1wIzNabXG2NbdGe4uTjCUVNS51h9gG7cDeXuOiIioAcixZp7U23xpN+5arVWCzt3ZqgXsOfoSScvW2NqsFJMmIiIimch1m8+S+ilAnlt9UsbIkVgZC9ilLqRsS5g0ERERyaiu2ajH3V1kq5+Ss1WC1DFyzGpJqcXaPKlvjdexsbCmSSasaSIiIjlZu1UCUHtNk6V1VnW1XADqrsWyBtY0ERER2Tlrtkp4bd1R/HXdUdnqrKTMWBnjrOuWoS3hTJNMONNERESNoa4ZqUpBwPRvTtXaANPd5cFTavlF5TWOaal2hL64HDfvFsvWANTeZpqYNMmESRMREdkqKbf6gNpbAEhJvqQmVvGT+0IQpN0ObGhMmhoBkyYiImrq5JjV8nRTYtmI7pL6WcVPbvhicEt+v/kLTERERJJo1E41Npw0Jjdx4/tUm1gZnww0zmp5uikBoNpaLGNyZRxrK2wrGiIiIrJrUhIrQFpyZWsLBDNpIiIiIquTmlzZErYcICIiIpKASRMRERGRBEyaiIiIiCRg0kREREQkAZMmIiIiIgmYNBEREZFNMpSU45a+uNp9t/TFMJSUWzUeJk0PWbt2LZ544gmo1WoEBgYiJSWlsUMiIiJqdgwl5QjfmILQ9clmC/1m5RcjdH0ywjemWDVxYtJURXx8PKKiorBo0SKcPHkSAQEBCAkJQW5ubmOHRkRE1KwUllbgTkEZrucVIWzD74lT1aVW7hSUobC0wmoxMWmqYuXKlZg4cSLGjRsHf39/rFu3Di4uLti4cWNjh0ZERNSs+GgfLKnSzsNFTJxSr+WZrE23eVLDr01XFZOm/ygrK0NqaiqCg4PFbQ4ODggODkZSUpLZ+NLSUhgMBpMXERERyce4Fp0xcRoRm2S2yK81MWn6j3//+9+4f/8+vLy8TLZ7eXkhOzvbbHxMTAy0Wq348vX1tVaoREREzYbO3RmrQgNMtq0KDbB6wgQwaaq3efPmQa/Xi68bN240dkhERERNTlZ+MSLjT5tsi4w/bVYcbg1Mmv7jscceQ4sWLZCTk2OyPScnB97e3mbjVSoVNBqNyYuIiIjkU7Xou52HC7ZOCTKpcbJ24sSk6T+USiV69eqFffv2idsqKyuxb98+BAUFNWJkREREzc8tfbFZ0XcvPw+z4vCa+jg1BCZNVURFReHzzz9HXFwc0tPTMWXKFBQWFmLcuHGNHRoREVGz4qpyhKeb0qzou2pxuKebEq4qR6vFZL1vsgOhoaG4ffs2Fi5ciOzsbPTo0QN79uwxKw4nIiKihqVROyFufB8UllaYtRXQuTsjfnJfuKocoVE7WS0mJk0PmT59OqZPn97YYRARETV7GrVTjUmRNfszGfH2HBEREZEETJqIiIiIJGDSRERERCQBkyYiIiIiCZg0EREREUnApImIiIhIAiZNRERERBIwaSIiIiKSgEkTERERkQTsCC4TQRAAAAaDQdbjFpVVoLK0SDx2hZL/yIiIiORi/N02/o7XRiFIGUV1unnzJnx9fRs7DCIiIqqHGzduoG3btrWOYdIkk8rKSmRlZaFly5ZQKBSyHttgMMDX1xc3btyARqOR9dj0O15n6+B1tg5eZ+vhtbaOhrrOgiDg3r170Ol0cHCovWqJ93pk4uDgUGeG+qg0Gg3/g7QCXmfr4HW2Dl5n6+G1to6GuM5arVbSOBaCExEREUnApImIiIhIAiZNdkClUmHRokVQqVSNHUqTxutsHbzO1sHrbD281tZhC9eZheBEREREEnCmiYiIiEgCJk1EREREEjBpIiIiIpKASRMRERGRBEyabMTatWvxxBNPQK1WIzAwECkpKbWO37JlCzp16gS1Wo1u3bph9+7dVorUvllynT///HMMGDAArVq1QqtWrRAcHFznPxd6wNJ/n402b94MhUKBYcOGNWyATYSl1zk/Px/Tpk2Dj48PVCoVOnTowL87JLD0Ov/9739Hx44d4ezsDF9fX0RGRqKkpMRK0dqnxMREDB06FDqdDgqFAtu3b6/zMwcPHkTPnj2hUqnw1FNPYdOmTQ0eJwRqdJs3bxaUSqWwceNG4fz588LEiRMFd3d3IScnp9rxR44cEVq0aCEsX75cuHDhgvDuu+8KTk5OwtmzZ60cuX2x9DqPGjVKWLt2rXDq1CkhPT1dePPNNwWtVivcvHnTypHbF0uvs1FmZqbw+OOPCwMGDBBeffVV6wRrxyy9zqWlpULv3r2FwYMHC4cPHxYyMzOFgwcPCmlpaVaO3L5Yep2//vprQaVSCV9//bWQmZkp7N27V/Dx8REiIyOtHLl92b17tzB//nzh+++/FwAI27Ztq3X81atXBRcXFyEqKkq4cOGC8MknnwgtWrQQ9uzZ06BxMmmyAX369BGmTZsmvr9//76g0+mEmJiYase//vrrwpAhQ0y2BQYGCpMnT27QOO2dpdf5YRUVFULLli2FuLi4hgqxSajPda6oqBCeffZZ4YsvvhDCw8OZNElg6XWOjY0V/vCHPwhlZWXWCrFJsPQ6T5s2Tfjzn/9ssi0qKkro169fg8bZlEhJmt555x2hS5cuJttCQ0OFkJCQBoxMEHh7rpGVlZUhNTUVwcHB4jYHBwcEBwcjKSmp2s8kJSWZjAeAkJCQGsdT/a7zw4qKilBeXg4PD4+GCtPu1fc6L1myBG3atEFERIQ1wrR79bnOP/zwA4KCgjBt2jR4eXmha9eu+PDDD3H//n1rhW136nOdn332WaSmpoq38K5evYrdu3dj8ODBVom5uWis30Eu2NvI/v3vf+P+/fvw8vIy2e7l5YWLFy9W+5ns7Oxqx2dnZzdYnPauPtf5YdHR0dDpdGb/odLv6nOdDx8+jC+//BJpaWlWiLBpqM91vnr1Kvbv34/Ro0dj9+7duHLlCqZOnYry8nIsWrTIGmHbnfpc51GjRuHf//43+vfvD0EQUFFRgbfeegv/7//9P2uE3GzU9DtoMBhQXFwMZ2fnBvlezjQRSbB06VJs3rwZ27Ztg1qtbuxwmox79+5hzJgx+Pzzz/HYY481djhNWmVlJdq0aYMNGzagV69eCA0Nxfz587Fu3brGDq1JOXjwID788EN89tlnOHnyJL7//nvs2rUL77//fmOHRjLgTFMje+yxx9CiRQvk5OSYbM/JyYG3t3e1n/H29rZoPNXvOht9/PHHWLp0KX7++Wd07969IcO0e5Ze519++QW//vorhg4dKm6rrKwEADg6OiIjIwNPPvlkwwZth+rz77OPjw+cnJzQokULcVvnzp2RnZ2NsrIyKJXKBo3ZHtXnOi9YsABjxozBhAkTAADdunVDYWEhJk2ahPnz58PBgXMVcqjpd1Cj0TTYLBPAmaZGp1Qq0atXL+zbt0/cVllZiX379iEoKKjazwQFBZmMB4CEhIQax1P9rjMALF++HO+//z727NmD3r17WyNUu2bpde7UqRPOnj2LtLQ08fXKK6/g+eefR1paGnx9fa0Zvt2oz7/P/fr1w5UrV8SkFAAuXboEHx8fJkw1qM91LioqMkuMjImqwKVeZdNov4MNWmZOkmzevFlQqVTCpk2bhAsXLgiTJk0S3N3dhezsbEEQBGHMmDHC3LlzxfFHjhwRHB0dhY8//lhIT08XFi1axJYDElh6nZcuXSoolUrhn//8p3Dr1i3xde/evcY6Bbtg6XV+GJ+ek8bS63z9+nWhZcuWwvTp04WMjAxh586dQps2bYS//e1vjXUKdsHS67xo0SKhZcuWwrfffitcvXpV+Omnn4Qnn3xSeP311xvrFOzCvXv3hFOnTgmnTp0SAAgrV64UTp06JVy7dk0QBEGYO3euMGbMGHG8seXAnDlzhPT0dGHt2rVsOdCcfPLJJ0K7du0EpVIp9OnTR0hOThb3Pffcc0J4eLjJ+O+++07o0KGDoFQqhS5dugi7du2ycsT2yZLr7OfnJwAwey1atMj6gdsZS/99ropJk3SWXuejR48KgYGBgkqlEv7whz8IH3zwgVBRUWHlqO2PJde5vLxcWLx4sfDkk08KarVa8PX1FaZOnSrcvXvX+oHbkQMHDlT7963x2oaHhwvPPfec2Wd69OghKJVK4Q9/+IPw1VdfNXicCkHgfCERERFRXVjTRERERCQBkyYiIiIiCZg0EREREUnApImIiIhIAiZNRERERBIwaSIiIiKSgEkTERERkQRMmoiIiIgkYNJERHbv4MGDUCgUyM/Pt+r3btq0Ce7u7o90jF9//RUKhQJpaWk1jmms8yMiU0yaiMimKRSKWl+LFy9u7BCJqJlwbOwAiIhqc+vWLfHP8fHxWLhwITIyMsRtbm5uOHHihMXHLSsrg1KplCVGImoeONNERDbN29tbfGm1WigUCpNtbm5u4tjU1FT07t0bLi4uePbZZ02Sq8WLF6NHjx744osv0L59e6jVagBAfn4+JkyYgNatW0Oj0eDPf/4zTp8+LX7u9OnTeP7559GyZUtoNBr06tXLLEnbu3cvOnfuDDc3N7z44osmiV5lZSWWLFmCtm3bQqVSoUePHtizZ0+t57x792506NABzs7OeP755/Hrr78+yiUkIpkwaSKiJmP+/PlYsWIFTpw4AUdHR4wfP95k/5UrV7B161Z8//33Yg3RX//6V+Tm5uLHH39EamoqevbsiRdeeAF5eXkAgNGjR6Nt27Y4fvw4UlNTMXfuXDg5OYnHLCoqwscff4z/+Z//QWJiIq5fv47//u//FvevXr0aK1aswMcff4wzZ84gJCQEr7zyCi5fvlztOdy4cQPDhw/H0KFDkZaWhgkTJmDu3LkyXykiqheBiMhOfPXVV4JWqzXbfuDAAQGA8PPPP4vbdu3aJQAQiouLBUEQhEWLFglOTk5Cbm6uOOZf//qXoNFohJKSEpPjPfnkk8L69esFQRCEli1bCps2baoxHgDClStXxG1r164VvLy8xPc6nU744IMPTD73zDPPCFOnThUEQRAyMzMFAMKpU6cEQRCEefPmCf7+/ibjo6OjBQDC3bt3q42DiKyDM01E1GR0795d/LOPjw8AIDc3V9zm5+eH1q1bi+9Pnz6NgoICeHp6ws3NTXxlZmbil19+AQBERUVhwoQJCA4OxtKlS8XtRi4uLnjyySdNvtf4nQaDAVlZWejXr5/JZ/r164f09PRqzyE9PR2BgYEm24KCgiRfAyJqOCwEJ6Imo+ptM4VCAeBBTZGRq6uryfiCggL4+Pjg4MGDZscythJYvHgxRo0ahV27duHHH3/EokWLsHnzZvzlL38x+07j9wqCIMfpEJGN4UwTETVbPXv2RHZ2NhwdHfHUU0+ZvB577DFxXIcOHRAZGYmffvoJw4cPx1dffSXp+BqNBjqdDkeOHDHZfuTIEfj7+1f7mc6dOyMlJcVkW3JysoVnRkQNgUkTETVbwcHBCAoKwrBhw/DTTz/h119/xdGjRzF//nycOHECxcXFmD59Og4ePIhr167hyJEjOH78ODp37iz5O+bMmYNly5YhPj4eGRkZmDt3LtLS0jBz5sxqx7/11lu4fPky5syZg4yMDHzzzTfYtGmTTGdMRI+Ct+eIqNlSKBTYvXs35s+fj3HjxuH27dvw9vbGwIED4eXlhRYtWuDOnTsYO3YscnJy8Nhjj2H48OF47733JH/HjBkzoNfrMXv2bOTm5sLf3x8//PAD/vjHP1Y7vl27dti6dSsiIyPxySefoE+fPvjwww/NngQkIutTCLz5TkRERFQn3p4jIiIikoBJExEREZEETJqIiIiIJGDSRERERCQBkyYiIiIiCZg0EREREUnApImIiIhIAiZNRERERBIwaSIiIiKSgEkTERERkQRMmoiIiIgk+P+Lp094t8QHdwAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk0AAAGwCAYAAAC0HlECAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy89olMNAAAACXBIWXMAAA9hAAAPYQGoP6dpAABbk0lEQVR4nO3deXiTVd4+8DslJF3TsrWl0iKgsokiMpZC2aRQBsRBfEeBDiBW0BFkUwR+DIvOKIjigiIMLgPjiAsqbqylUGoXWQqV1QpSbBHbgtCEttD1/P54fJI8SVqSkjRJe3+uq5fmyUl6kpl3er/nfJ/vUQkhBIiIiIioTj7ungARERGRN2BoIiIiIrIDQxMRERGRHRiaiIiIiOzA0ERERERkB4YmIiIiIjswNBERERHZQe3uCTQWNTU1OH/+PIKCgqBSqdw9HSIiIrKDEAJXrlxBREQEfHzqXktiaHKS8+fPIzIy0t3TICIionrIz89Hu3bt6hzD0OQkQUFBAKQvXafTuXk2REREZA+DwYDIyEjj3/G6MDQ5ibwlp9PpGJqIiIi8jD2lNSwEJyIiIrIDQxMRERGRHRiaiIiIiOzA0ERERERkB4YmIiIiIjswNBERERHZgaGJiIiIyA4MTURERER2YGgiIiIisgNDk6eq0ANl52w/V3ZOep6IiIgaDEOTJ6rQA3uGA7sGAqX5yudK86Xre4YzOBERETUghiZPVHUFKC8CSs4AyYNMwak0X3pcckZ6vuqKO2dJRETUpDA0eSL/dsCQFCCwoyk4XcgwBabAjtLz/u3cOUsiIqImhaHJUwVEKoNTUj9lYAqIdO/8iIiImhiGJk8WEAnEfKC8FvMBAxMREZEbMDR5stJ8IHOC8lrmBOvicCIiInI5hiZPZV70HdgRGJqurHFicCIiImpQDE2eqOycddF3m77WxeG19XEiIiIip2No8kTqIEAbal30bV4crg2VxhEREVGDULt7AmSDJhgYvF3qw2TZViAgEojbKwUmTbB75kdERNQEMTR5Kk1w7aGI/ZmIiIgaHLfniIiIiOzA0ERERERkB4YmIiIiIjswNBERERHZgaGJiIiIyA4MTURERER2YGgiIiIisgNDExEREZEd3BqaUlNTMWrUKEREREClUuHLL7+sdewTTzwBlUqF119/XXH90qVLSEhIgE6nQ0hICBITE1FSUqIYc+TIEfTv3x++vr6IjIzEihUrrN5/06ZN6NKlC3x9fdGjRw9s3brVGR+RiIiIGgm3hqbS0lLceeedWL16dZ3jNm/ejO+//x4RERFWzyUkJOD48eNISkrCt99+i9TUVEydOtX4vMFgwLBhw9C+fXtkZWXh5ZdfxtKlS7Fu3TrjmIyMDIwbNw6JiYk4fPgwRo8ejdGjR+PYsWPO+7BERETk3YSHACA2b95sdf3cuXPipptuEseOHRPt27cXr732mvG5EydOCADiwIEDxmvbtm0TKpVK/Prrr0IIId5++23RokULUV5ebhwzb9480blzZ+Pjhx56SIwcOVLxe6Ojo8Xjjz9u9/z1er0AIPR6vd2vISIiIvdy5O+3R9c01dTUYMKECZg7dy66d+9u9XxmZiZCQkLQu3dv47W4uDj4+Phg3759xjEDBgyARqMxjomPj0dOTg4uX75sHBMXF6d47/j4eGRmZtY6t/LychgMBsUPERERNV4eHZpeeuklqNVqzJgxw+bzBQUFCA0NVVxTq9Vo2bIlCgoKjGPCwsIUY+TH1xsjP2/LsmXLEBwcbPyJjIx07MMRERGRV/HY0JSVlYU33ngD69evh0qlcvd0rCxYsAB6vd74k5+f7+4pERERkQt5bGj67rvvUFRUhKioKKjVaqjVavzyyy94+umncfPNNwMAwsPDUVRUpHhdVVUVLl26hPDwcOOYwsJCxRj58fXGyM/botVqodPpFD9ERETUeHlsaJowYQKOHDmC7Oxs409ERATmzp2LHTt2AABiYmJQXFyMrKws4+t2796NmpoaREdHG8ekpqaisrLSOCYpKQmdO3dGixYtjGOSk5MVvz8pKQkxMTGu/phERETkJdTu/OUlJSU4ffq08XFubi6ys7PRsmVLREVFoVWrVorxzZs3R3h4ODp37gwA6Nq1K4YPH44pU6Zg7dq1qKysxPTp0zF27Fhje4Lx48fjueeeQ2JiIubNm4djx47hjTfewGuvvWZ835kzZ2LgwIFYuXIlRo4ciY8//hgHDx5UtCUgIiKiJq4B7uar1Z49ewQAq59JkybZHG/ZckAIIX7//Xcxbtw4ERgYKHQ6nZg8ebK4cuWKYswPP/wgYmNjhVarFTfddJNYvny51Xt/+umn4rbbbhMajUZ0795dbNmyxaHPwpYDRERE3seRv98qIYRwY2ZrNAwGA4KDg6HX61nfRERE5CUc+fvtsTVNRERERJ6EoYmIiIjIDgxNRERERHZgaCIiIiKyA0MTERERkR0YmoiIiIjswNBEREREZAeGJiIiIiI7MDQRERER2YGhiYiIiMgODE1EREREdmBoIiIiIrIDQxMRERGRHRiaiIiIiOzA0ERERERkB4YmIiIiIjswNBERERHZgaGJiIiIyA4MTd6iQg+UnbP9XNk56XkiIiJyGYYmb1ChB/YMB3YNBErzlc+V5kvX9wxncCIiInIhhiZvUHUFKC8CSs4AyYNMwak0X3pcckZ6vuqKO2dJRETUqDE0eQP/dsCQFCCwoyk4XcgwBabAjtLz/u3cOUsiIqJGjaHJWwREKoNTUj9lYAqIdO/8iIiIGjmGJm8SEAnEfKC8dtdK24GJxeFEREROxdDkTUrzgcwJymtpfwUu7rMex+JwIiIip2Jo8hbmRd+BHYH+mwGVGhBVQFKsKTixOJyIiMglGJq8Qdk566LvyNHA0DRlcMr/ksXhRERELsLQ5A3UQYA21Lrou3W0Mjh99wCLw4mIiFyEockbaIKBwduBuL3WQah1NBC7SXkt5gMGJiIiIidjaPIWmmDbW22l+cDhp5XXMidYdw4nIiKiG8LQ5M0si8MH7QD8o6w7hwNsQUBERHSDGJq8lWVx+ICvgaNLpOfMg5P+BHBxv+0WBAxSREREdlO7ewJUT3JxOCAVfatUUouBsjwpNPlHAc1bAunjAf1xqVAckFoQaIJNq1TaUKleShPspg9CRETkHbjS5K0si8PNz6cry5PGdJ5lCkwqNdB3ozSOvZyIiIgcxtDkzSyLw83PpyvLA77/mykwiSogYzwP+iUiIqont4am1NRUjBo1ChEREVCpVPjyyy+Nz1VWVmLevHno0aMHAgICEBERgYkTJ+L8+fOK97h06RISEhKg0+kQEhKCxMRElJSUKMYcOXIE/fv3h6+vLyIjI7FixQqruWzatAldunSBr68vevToga1bt7rkM7ucrfPpYj/lQb9EREQ3yK2hqbS0FHfeeSdWr15t9VxZWRkOHTqERYsW4dChQ/jiiy+Qk5OD+++/XzEuISEBx48fR1JSEr799lukpqZi6tSpxucNBgOGDRuG9u3bIysrCy+//DKWLl2KdevWGcdkZGRg3LhxSExMxOHDhzF69GiMHj0ax44dc92HdxVb59Mdfga46xXlNfZyIiIicohKCCHcPQkAUKlU2Lx5M0aPHl3rmAMHDuCee+7BL7/8gqioKJw8eRLdunXDgQMH0Lt3bwDA9u3bMWLECJw7dw4RERFYs2YNFi5ciIKCAmg0GgDA/Pnz8eWXX+LHH38EADz88MMoLS3Ft99+a/xdffr0Qc+ePbF27Vq75m8wGBAcHAy9Xg+dTlfPb+EGWbYgiPlAClAlZ0xbdDKuNBERETn099urapr0ej1UKhVCQkIAAJmZmQgJCTEGJgCIi4uDj48P9u3bZxwzYMAAY2ACgPj4eOTk5ODy5cvGMXFxcYrfFR8fj8zMzFrnUl5eDoPBoPhxK1vn07XpKxV/y4FJpZYO+pW36ix7OREREVGtvCY0Xbt2DfPmzcO4ceOMSbCgoAChoaGKcWq1Gi1btkRBQYFxTFhYmGKM/Ph6Y+TnbVm2bBmCg4ONP5GRbl6xsXU+Xdk5qfhbDkzBPYCWvYC+HymDU9k56T3Yt4mIiKhWXhGaKisr8dBDD0EIgTVr1rh7OgCABQsWQK/XG3/y8928YmPrfDrzIDU0HRj4JZD2MJAxTlqBCuwoPa8OklacbDXAJCIiIgBe0NxSDky//PILdu/erdhvDA8PR1FRkWJ8VVUVLl26hPDwcOOYwsJCxRj58fXGyM/botVqodVq6//BXEETrGxSKQepqitSW4Gyc1JfppIz0gpU348AXWeg0mDa2gNMDTCJiIjIyKNXmuTAdOrUKezatQutWrVSPB8TE4Pi4mJkZWUZr+3evRs1NTWIjo42jklNTUVlZaVxTFJSEjp37owWLVoYxyQnJyveOykpCTExMa76aA3HvJeTeQPMkjPSipP+OPs2ERER2cGtoamkpATZ2dnIzs4GAOTm5iI7Oxt5eXmorKzE//3f/+HgwYP48MMPUV1djYKCAhQUFKCiogIA0LVrVwwfPhxTpkzB/v37kZ6ejunTp2Ps2LGIiIgAAIwfPx4ajQaJiYk4fvw4PvnkE7zxxhuYM2eOcR4zZ87E9u3bsXLlSvz4449YunQpDh48iOnTpzf4d+Jy5g0w2beJiIjIfsKN9uzZIwBY/UyaNEnk5ubafA6A2LNnj/E9fv/9dzFu3DgRGBgodDqdmDx5srhy5Yri9/zwww8iNjZWaLVacdNNN4nly5dbzeXTTz8Vt912m9BoNKJ79+5iy5YtDn0WvV4vAAi9Xl+v76LBFaUL8SFMP0Xp7p4RERFRg3Pk77fH9Gnydh7Rp8le5v2cZFxpIiKiJqjR9mkiJ7BsgDk0HQi4ufa+TWxDQEREBIChqWmx1QAzuDugaSn1cbLs28Q2BEREREYe33KAnEju2wQoG2BWFpsaYKqDTX2b2IaAiIjIiCtNTYmtBpjmbQhEFVB5mW0IiIiIbGBoamrM+zbJzNsQlJ5lGwIiIiIbGJpIEhAJxHygvBbzAQMTERHRHxiaSFKaD2ROUF5LH2d9Nx3AO+qIiKhJYmgi6zYEg3YAPlqgLA9IilUGJ95RR0RETRRDU1Nnqw1BSDfAN+yP5/8ITmXnlOGqvEi6o46IiKiJYGhq6uQ2BOZF3/7tgKFpgH+UNOZaIVB8gnfUERFRk8ZjVJzEq45RsVShl1aNLENQaf4fq0x5pmu8o46IiBoRHqNCjrHVhgCQglG/j5TXbN1Rx8JwIiJqAhiaqHb23FHHwnAiImoiGJrINvOib/8owC9Cum5+Rx0Lw4mIqAnh2XNkzdYddYCpvqksD9jZRzqrriyPheFERNQkcKWJrNm6oy4gUnlH3dXzysDEwnAiImrkGJrImq2DfQH7C8OJiIgaIYYmss3WHXW2CsMzJ9g+aoWIiKiRYWgi+1getTI0XfpnyRnpOoMTERE1cg6Hpu3btyMtLc34ePXq1ejZsyfGjx+Py5cvO3Vy5CFsFYa36QsM+FqqcZKDU9k55WvYgoCIiBoRh0PT3LlzYTAYAABHjx7F008/jREjRiA3Nxdz5sxx+gTJA9gqDK/QA/sek573j5KeVwdJj9m7iYiIGiGHWw7k5uaiW7duAIDPP/8c9913H1588UUcOnQII0aMcPoEyQPIheHmR61UXZF6M5XlSaEp+l1pnPk2njxOE+y2qRMRETmLwytNGo0GZWVlAIBdu3Zh2LBhAICWLVsaV6CoEbIsDPdvJ606BXaUglPq/cCFDB7qS0REjZbDK02xsbGYM2cO+vXrh/379+OTTz4BAPz0009o145/IJuUgEgpGMlBKamfdJ29m4iIqBFyeKXprbfeglqtxmeffYY1a9bgpptuAgBs27YNw4cPd/oEycMFREq9msyxdxMRETVCKiGEcPckGgODwYDg4GDo9XrodDp3T6fhWNYwAVxpIiIir+HI32+7tuccqVVqUoGhqbPs3RTzgdTsUm5BMCSFwYmIiBoNu0JTSEgIVCqVXW9YXV19QxMiL2Grd5NljVPyIOkoFhaDExFRI2BXaNqzZ4/x38+ePYv58+fjkUceQUxMDAAgMzMTGzZswLJly1wzS/I8cu8mQNm7SaUyBSfz3k1l56R/Z/sBIiLyUg7XNA0ZMgSPPfYYxo0bp7i+ceNGrFu3DikpKc6cn9dokjVNFXpT76YKvdTMsrxICk0qlSkkydt42lCp3xODExEReQhH/n47fPdcZmYmevfubXW9d+/e2L9/v6NvR97MvHeT3OxS3pYTwrrZZXmRNI6IiMgLORyaIiMj8c4771hdf/fddxEZyaLfJsu82aUcnNjskoiIGhGHm1u+9tprePDBB7Ft2zZER0cDAPbv349Tp07h888/d/oEyYuw2SURETViDq80jRgxAqdOncKoUaNw6dIlXLp0CaNGjcJPP/3Es+eIzS6JiKjRYnNLJ2mSheC2sNklERF5EZcWggNAcXExdu7cif/973/473//q/hxRGpqKkaNGoWIiAioVCp8+eWXiueFEFi8eDHatm0LPz8/xMXF4dSpU4oxly5dQkJCAnQ6HUJCQpCYmIiSkhLFmCNHjqB///7w9fVFZGQkVqxYYTWXTZs2oUuXLvD19UWPHj2wdetWhz4LwbrZ5dB0ZY1Tab67Z0hERFRvDtc0ffPNN0hISEBJSQl0Op2i6aVKpcLEiRPtfq/S0lLceeedePTRRzFmzBir51esWIFVq1Zhw4YN6NChAxYtWoT4+HicOHECvr6+AICEhAT89ttvSEpKQmVlJSZPnoypU6di48aNAKQEOWzYMMTFxWHt2rU4evQoHn30UYSEhGDq1KkAgIyMDIwbNw7Lli3Dfffdh40bN2L06NE4dOgQbr/9dke/oqaptmaXA74GUkbYbnbJ3k1ERORNhINuvfVWMXPmTFFaWuroS+sEQGzevNn4uKamRoSHh4uXX37ZeK24uFhotVrx0UcfCSGEOHHihAAgDhw4YByzbds2oVKpxK+//iqEEOLtt98WLVq0EOXl5cYx8+bNE507dzY+fuihh8TIkSMV84mOjhaPP/54rfO9du2a0Ov1xp/8/HwBQOj1+vp9Ad6uvFiI7X2E+KqjECV5ymubo6Sf7X2ka0JIY77qqLxGRETUwPR6vd1/vx3envv1118xY8YM+Pv7Ozu/KeTm5qKgoABxcXHGa8HBwYiOjkZmZiYAqWdUSEiIom9UXFwcfHx8sG/fPuOYAQMGQKPRGMfEx8cjJycHly9fNo4x/z3yGPn32LJs2TIEBwcbf5p8uwVNsNS4Mm6vqXZJ7t1Ulic9jn6XvZuIiMhrORya4uPjcfDgQVfMRaGgoAAAEBYWprgeFhZmfK6goAChoaGK59VqNVq2bKkYY+s9zH9HbWPk521ZsGAB9Hq98Sc/n/U6imaXgLJ3U1kekHo/ezcREZHXcrimaeTIkZg7dy5OnDiBHj16oHnz5orn77//fqdNzpNptVpotVp3T8PzOdK7iTVORETkwRwOTVOmTAEAPP/881bPqVQqVFdX3/isAISHhwMACgsL0bZtW+P1wsJC9OzZ0zimqKhI8bqqqipcunTJ+Prw8HAUFhYqxsiPrzdGfp5ukNy7SQ5MAHDXK8rAxPPpiIjIwzm8PVdTU1Prj7MCEwB06NAB4eHhSE5ONl4zGAzYt28fYmJiAAAxMTEoLi5GVlaWcczu3btRU1Nj7FYeExOD1NRUVFZWGsckJSWhc+fOaNGihXGM+e+Rx8i/h25QaT6QOUF5Le0h4OI+0/OscSIiIg9Xrz5NzlJSUoLs7GxkZ2cDkIq/s7OzkZeXB5VKhVmzZuFf//oXvv76axw9ehQTJ05EREQERo8eDQDo2rUrhg8fjilTpmD//v1IT0/H9OnTMXbsWERERAAAxo8fD41Gg8TERBw/fhyffPIJ3njjDcyZM8c4j5kzZ2L79u1YuXIlfvzxRyxduhQHDx7E9OnTG/oraXwsezf1/wJQqQFRBSTFAvmbWeNEREReweGO4La25cwtXrzY7vdKSUnB4MGDra5PmjQJ69evhxACS5Yswbp161BcXIzY2Fi8/fbbuO2224xjL126hOnTp+Obb76Bj48PHnzwQaxatQqBgYHGMUeOHMG0adNw4MABtG7dGk899RTmzZun+J2bNm3CP/7xD5w9exa33norVqxY4dCxMOwIbkPZOWDXQOveTRf3SYFJVJnGsms4ERG5gSN/vx0OTXfddZficWVlJXJzc6FWq9GpUyccOnTI8Rk3AgxNNlTogT3DpS23ISnKQJS/GfjOrKFp/81A5Gjr92BxOBERuZAjf78dLgQ/fPiwzV/4yCOP4IEHHnD07agxk3s3VV1RbrmV5gOHn1GOTfsrMDQNaB2tHMficCIi8hBOqWnS6XR47rnnsGjRIme8HTUmlr2brGqcNitrnFgcTkREHsppheByk0eiWtk6ny5ytLTCpCgO/5LF4URE5HEc3p5btWqV4rEQAr/99hs++OAD/PnPf3baxKgRUgdJW22AssapdbQUnOTi8O/+2OZlcTgREXkQhwvBO3TooHjs4+ODNm3a4N5778WCBQsQFBTk1Al6CxaC26lCb13jJMv/0hSYAGBoOtCmr3IMC8OJiMiJXFoInpubW++JEUETbDvwlOYDh59WXksfJ61AyStNLAwnIiI3uqGapnPnzuHcuXPOmgs1VeZF3/5RgJ/UmBRledKWXWk+C8OJiMjt6nWMyvPPP4/g4GC0b98e7du3R0hICP75z3+ipqbGFXOkxsyyOHxoGjDseyk8AVJw2tlHCk8sDCciIjdyeHtu4cKFeO+997B8+XL06ycdwJqWloalS5fi2rVreOGFF5w+SWrEaisOlwvDy/KAq+elaywMJyIiN3K4EDwiIgJr167F/fffr7j+1Vdf4cknn8Svv/7q1Al6CxaC34DaisMvZABJ/UyP2TWciIiczJG/3w5vz126dAldunSxut6lSxdcunTJ0bcjsm6ACUg1TJkTlNfS/mpqfmk+btdA6biWCvYJIyIi13E4NN1555146623rK6/9dZbuPPOO50yKWri2DWciIg8kMM1TStWrMDIkSOxa9cuxMTEAAAyMzORn5+PrVu3On2C1MTY6hoeEKlsfpkUC8RukloUsDiciIgaiMMrTQMHDsRPP/2EBx54AMXFxSguLsaYMWOQk5OD/v37u2KO1JTIheGWRd9y13B5xem7B6yDFRERkQs5XAhOtrEQ3Ikc6RrO4nAiIroBLu0IDgCXL1/Ge++9h5MnTwIAunXrhsmTJ6Nly5b1eTsiJUe6hqf9VVqBah2tHMfO4URE5GQOb8+lpqbi5ptvxqpVq3D58mVcvnwZq1atQocOHZCamuqKORKxOJyIiNzO4e25Hj16ICYmBmvWrEGzZs0AANXV1XjyySeRkZGBo0ePumSino7bcy5Udk5qK2BZw3Rxn6k4XKW2XRzOWiciIqqDI3+/HQ5Nfn5+yM7ORufOnRXXc3Jy0LNnT1y9etXxGTcCDE0uVKGX+jCVF1kHIfPgJGNgIiIiO7m0uWWvXr2MtUzmTp48yT5N5BqaYKk2KW6vdRBqHS2tMJmL+YCBiYiInM7hQvAZM2Zg5syZOH36NPr06QMA+P7777F69WosX74cR44cMY694447nDdTatocKQ7PnMCVJiIicjqHt+d8fOpenFKpVBBCQKVSobq6+oYm5024PecGlsXhMR9IgYk1TUREZCeXthzIzc2t98SInMZW5/DmOqDvR0DGOOl68iBpS8+/Hfs2ERHRDXM4NLVv394V8yByjNw5HDAFJrlYvO9GIGO89Lw6iH2biIjIKerV3PL8+fNIS0tDUVERampqFM/NmDHDKRMjqpNcHC53Di87JwWmkjNSYOr7EaDrDFQaTCtSgDSeoYmIiOrB4Zqm9evX4/HHH4dGo0GrVq2gUqlMb6ZS4cyZM06fpDdgTZMHsFXjlJEAlJ61XePELTsioibPpX2aIiMj8cQTT2DBggXXLQpvShiaPIR5cJKp1DxqhYiIbHJpn6aysjKMHTuWgYk8U0CktMJkTlRJW3al+VKjzIv7bR+1UnZOep6IiMgGh5NPYmIiNm3adP2BRO5Qmi+1HTCnUksBadcAIKmf9GN+151/O+l1uwZKxeQMTkREZIPD23PV1dW47777cPXqVfTo0QPNmzdXPP/qq686dYLegttzHqCuvk3y4b4y8y07y9fJbQqIiKjRc2mfpmXLlmHHjh3Gs+csC8GJ3MJW36aASOmfljVOgGnLzlaxuHlgYrE4ERH9weGVphYtWuC1117DI4884qIpeSeuNLmZo4f61rXyJGOxOBFRo+fSQnCtVot+/frVe3JELlHbob6l+dKKkqgCAm4GhqZLK0rmgQlQFovLr7NVLE5ERE2Ww6Fp5syZePPNN10xF6Ibowm23lpT1CqlAm36Sh3DVRY703KxePIg4EKG9VYfa5yIiJo8h0PT/v37sWHDBnTs2BGjRo3CmDFjFD/OVF1djUWLFqFDhw7w8/NDp06d8M9//hPmO4pCCCxevBht27aFn58f4uLicOrUKcX7XLp0CQkJCdDpdAgJCUFiYiJKSkoUY44cOYL+/fvD19cXkZGRWLFihVM/C7mBfNSKeY2T+cqTSg3ouksrUPLjkjPWd9fx0F8iIkI9CsFDQkKcHo5q89JLL2HNmjXYsGEDunfvjoMHD2Ly5MkIDg42HteyYsUKrFq1Chs2bECHDh2waNEixMfH48SJE/D19QUAJCQk4LfffkNSUhIqKysxefJkTJ06FRs3bgQg7WcOGzYMcXFxWLt2LY4ePYpHH30UISEhmDp1aoN8VnIBW0etmK8g1XbUiizmA+vAxMJwIqImy+FC8IZ03333ISwsDO+9957x2oMPPgg/Pz/873//gxACERERePrpp/HMM88AAPR6PcLCwrB+/XqMHTsWJ0+eRLdu3XDgwAH07t0bALB9+3aMGDEC586dQ0REBNasWYOFCxeioKAAGo0GADB//nx8+eWX+PHHH+2aKwvBvYCjxeL+UVJxuDyOheFERI2OSwvBZRcuXEBaWhrS0tJw4cKF+r5Nnfr27Yvk5GT89NNPAIAffvgBaWlp+POf/wwAyM3NRUFBAeLi4oyvCQ4ORnR0NDIzMwEAmZmZCAkJMQYmAIiLi4OPjw/27dtnHDNgwABjYAKA+Ph45OTk4PLlyzbnVl5eDoPBoPghD2dPsbhfO8AvQrpelicFqdJ8FoYTEZHj23OlpaV46qmn8N///hc1NTUAgGbNmmHixIl488034e/v77TJzZ8/HwaDAV26dEGzZs1QXV2NF154AQkJCQCAgoICAEBYWJjidWFhYcbnCgoKEBoaqnherVajZcuWijEdOnSweg/5uRYtWljNbdmyZXjuueec8CmpQWmClStEtvo7AVJYKsuTfnb2keqdyvJYGE5E1IQ5vNI0Z84c7N27F9988w2Ki4tRXFyMr776Cnv37sXTTz/t1Ml9+umn+PDDD7Fx40YcOnQIGzZswCuvvIINGzY49ffUx4IFC6DX640/+fn57p4S1YetYvGASGlbzj9KGnP1vDIwsTCciKhJcnil6fPPP8dnn32GQYMGGa+NGDECfn5+eOihh7BmzRqnTW7u3LmYP38+xo4dCwDo0aMHfvnlFyxbtgyTJk1CeHg4AKCwsBBt27Y1vq6wsBA9e/YEAISHh6OoqEjxvlVVVbh06ZLx9eHh4SgsLFSMkR/LYyxptVpotdob/5DkXpbF4rKASKDfR9KddDJbheFERNRkOLzSVFZWZrUdBgChoaEoKytzyqTMf5ePj3KKzZo1M24LdujQAeHh4UhOTjY+bzAYsG/fPsTExAAAYmJiUFxcjKysLOOY3bt3o6amBtHR0cYxqampqKysNI5JSkpC586dbW7NUSNj2d8JsH3wb/o4U/NLc2XneMgvEVET4HBoiomJwZIlS3Dt2jXjtatXr+K5554zBhVnGTVqFF544QVs2bIFZ8+exebNm/Hqq6/igQceACCddTdr1iz861//wtdff42jR49i4sSJiIiIwOjRowEAXbt2xfDhwzFlyhTs378f6enpmD59OsaOHYuICKngd/z48dBoNEhMTMTx48fxySef4I033sCcOXOc+nnIS1ge4DtoB+CjVRaGm4/dNVC6K4/BiYiocRMOOnr0qIiIiBCtWrUS9957r7j33ntFq1atxE033SSOHTvm6NvVyWAwiJkzZ4qoqCjh6+srOnbsKBYuXCjKy8uNY2pqasSiRYtEWFiY0Gq1YsiQISInJ0fxPr///rsYN26cCAwMFDqdTkyePFlcuXJFMeaHH34QsbGxQqvViptuukksX77cobnq9XoBQOj1+vp/YHK/0nwhvuooxIeQ/lmSJ13bHCVd+xDSvxcfF+LCPuXY0nzTe5QXu/dzEBGRXRz5+12vPk1lZWX48MMPjT2MunbtioSEBPj5+Tk50nkP9mlqJGrr5VSab7qjTqUBgjoBV05JbQosO46zlxMRkddw5O+3Rze39CYMTY1Ihd66MBxQBieZSi3dadc62npbL24vWxMQEXk4lza3XLZsGd5//32r6++//z5eeuklR9+OyPPYKgwHTHfUmRNVUmNMHvJLRNToORya/v3vf6NLly5W17t37461a9c6ZVJEHsnWHXU85JeIqMlwODQVFBQoeiLJ2rRpg99++80pkyLyOJZbb0PTpX+an1UHAHettB2Y2JaAiMjrORyaIiMjkZ6ebnU9PT3deAs/UaNi66iVNn2BvhullSZzaX+VDv81x7YERESNgsMdwadMmYJZs2ahsrIS9957LwAgOTkZzz77rNOPUSHyCPJRK4DyLjn5kF+VGgjoCJSekR4nxdouDgekAnPeUUdE5JUcDk1z587F77//jieffBIVFRUAAF9fX8ybNw8LFixw+gSJ3M7yqBXLlae+HwG6zoDhRykwycEpdhNw+GkWhxMRNRL1bjlQUlKCkydPws/PD7feemuTP4eNLQeakNp6OQHS1pwcnGQsDici8ljs0+QGDE1NTG29nAAg/0vguwdMj4emSzVQRETkcVzap4mIUHsvp9J8aUvOXOYE2wf9EhGRV2FoInKW2toSlJyRrjM4ERF5NYYmImeorS3BkBRlcCo7585ZEhHRDbArNPXq1QuXL18GADz//PMoKytz6aSIvI7clsCy6Dsg0hSctKHSOCIi8kp2FYL7+fnh1KlTaNeuHZo1a4bffvsNoaGhDTE/r8FCcKqzOLzsnBSY2KOJiMijOPL3264+TT179sTkyZMRGxsLIQReeeUVBAYG2hy7ePFix2dM1BhogmsPRezPRETk9exaacrJycGSJUvw888/49ChQ+jWrRvUauu8pVKpcOjQIZdM1NNxpYmIiMj7uLRPk4+PDwoKCrg9Z4GhiYiIyPs4fXvOXE1NTb0nRtTksM6JiKjRcDg0AcDPP/+M119/HSdPngQAdOvWDTNnzkSnTp2cOjkir1bXcStyTydtqHSuHYMTEZHHc7hP044dO9CtWzfs378fd9xxB+644w7s27cP3bt3R1JSkivmSOSdqq5Igcm8uWWFHri439TTqbxIGgdIK08VenfOmIiI6uBwTdNdd92F+Ph4LF++XHF9/vz52LlzJwvBWdNE5sy7hAfcDKgDAEOOdKCveU8nrjwREbmFS8+eO3nyJBITE62uP/roozhx4oSjb0fUuJk3tyw9C+iPS4FJpQb6blQGJsuVJyIi8igOh6Y2bdogOzvb6np2djbvqCOyJSASiPlAeU1UARnjgQsZ1sevsKcTEZFHcrgQfMqUKZg6dSrOnDmDvn37AgDS09Px0ksvYc6cOU6fIJHXK80HMicor6nUUlBK6ic9tjx+hYiIPI7DoWnRokUICgrCypUrsWDBAgBAREQEli5dihkzZjh9gkRezXzrLbCjtOKUOUF6bO6ulbYDE9sSEBF5DIcLwc1duSLVXgQF8RBSFoKTlbJzwK6Byq23gEjg4j4gKVbaopOp1MDQNKB1tOkai8OJiFzOpYXg5oKCghiYiGqjDpICj+VdchnjTcXggbdJ/xRVUpC6uE96LYvDiYg8Tr2aWxKRHTTB0gqR3BG87Jxyq67vR4CuM2D40bTylBQLxG4CDj/N4nAiIg/D0ETkSppg07aavPIEKIu+W0dLW3NycPruAek6i8OJiDzKDW3PEZED5JWnuL3WQah1tLTCZC7mA+tx7BpOROQ2DoWmyspKDBkyBKdOnXLVfIgaN02w7a220nxpS85c+jjpuvmYXQOl8+wYnIiIGpxDoal58+Y4cuSIq+ZC1DSZF337RwF+EdL1sjxpy640n4XhREQewOHtub/97W947733XDEXoqbHsjh8aBow7HspPAFScNrZB9jZt/bCcG7ZERE1CIcLwauqqvD+++9j165duPvuuxEQEKB4/tVXX3Xa5IgavdqKw+XC8LI84Op56Zr5eXUy9nIiImowDoemY8eOoVevXgCAn376SfGcSqVyzqyImgrLtgSygEig30emY1YA03l1Q1KsD/oFpPdgaCIichmHt+f27NlT68/u3budPsFff/0Vf/vb39CqVSv4+fmhR48eOHjwoPF5IQQWL16Mtm3bws/PD3FxcVaF6pcuXUJCQgJ0Oh1CQkKQmJiIkpISxZgjR46gf//+8PX1RWRkJFasWOH0z0Jkk63i8LrOq0sexIN+iYjcoN4tB06fPo0dO3bg6tWrAKTw4myXL19Gv3790Lx5c2zbtg0nTpzAypUr0aJFC+OYFStWYNWqVVi7di327duHgIAAxMfH49q1a8YxCQkJOH78OJKSkvDtt98iNTUVU6dONT5vMBgwbNgwtG/fHllZWXj55ZexdOlSrFu3zumfiei6LM+rG5ou/VPuIi4f9Gt5PAsREbmWcNDFixfFvffeK1QqlfDx8RE///yzEEKIyZMnizlz5jj6dnWaN2+eiI2NrfX5mpoaER4eLl5++WXjteLiYqHVasVHH30khBDixIkTAoA4cOCAccy2bduESqUSv/76qxBCiLffflu0aNFClJeXK353586da/3d165dE3q93viTn58vAAi9Xl/vz0skSvOF+KqjEB9C+mdJnnS9JM903fynKN32e5QXN+y8iYi8lF6vt/vvt8MrTbNnz0bz5s2Rl5cHf39/4/WHH34Y27dvd16aA/D111+jd+/e+Otf/4rQ0FDcddddeOedd4zP5+bmoqCgAHFxccZrwcHBiI6ORmZmJgAgMzMTISEh6N27t3FMXFwcfHx8sG/fPuOYAQMGQKPRGMfEx8cjJycHly9ftjm3ZcuWITg42PgTGcn/T5+cwNZ5dYD0z74bpZUmc+zlRETUYBwOTTt37sRLL72Edu2U9RO33norfvnlF6dNDADOnDmDNWvW4NZbb8WOHTvw97//HTNmzMCGDRsAAAUFBQCAsLAwxevCwsKMzxUUFCA0NFTxvFqtRsuWLRVjbL2H+e+wtGDBAuj1euNPfn6+zXFEDqmta7j5Qb9+7djLiYjIDRy+e660tFSxwiS7dOkStFqtUyYlq6mpQe/evfHiiy8CAO666y4cO3YMa9euxaRJk5z6uxyl1Wqd/nmJACjPqwOsezkNSZGuyy0J5F5OKrX07ywMJyJyCYdXmvr374///ve/xscqlQo1NTVYsWIFBg8e7NTJtW3bFt26dVNc69q1K/Ly8gAA4eHhAIDCwkLFmMLCQuNz4eHhKCoqUjxfVVWFS5cuKcbYeg/z30HkNra27AIipV5OchPMq+elwOQfZbswnA0wiYhumMOhacWKFVi3bh3+/Oc/o6KiAs8++yxuv/12pKam4qWXXnLq5Pr164ecnBzFtZ9++gnt27cHAHTo0AHh4eFITk42Pm8wGLBv3z7ExMQAAGJiYlBcXIysrCzjmN27d6OmpgbR0dHGMampqaisrDSOSUpKQufOnRV36hG5RW1bdnIvJ3Oiyvr1rHMiInIKh0PT7bffjp9++gmxsbH4y1/+gtLSUowZMwaHDx9Gp06dnDq52bNn4/vvv8eLL76I06dPY+PGjVi3bh2mTZsGQFrlmjVrFv71r3/h66+/xtGjRzFx4kRERERg9OjRAKSVqeHDh2PKlCnYv38/0tPTMX36dIwdOxYREVJdyPjx46HRaJCYmIjjx4/jk08+wRtvvIE5c+Y49fMQ1Zu9vZyunjfVOMljWOdEROQcDXA33w355ptvxO233y60Wq3o0qWLWLduneL5mpoasWjRIhEWFia0Wq0YMmSIyMnJUYz5/fffxbhx40RgYKDQ6XRi8uTJ4sqVK4oxP/zwg4iNjRVarVbcdNNNYvny5Q7N05FbFolumHkLgq86Sq0HNkeZWhFsjhLi1x2ma+btC4RgWwIioj848vdbJYTjXSkvX76M9957DydPngQAdOvWDZMnT0bLli2dHOm8h8FgQHBwMPR6PXQ6nbunQ41Z2Tlpu82yuWVpvqk43Jx/lFT/JG/t8bw6IiIjR/5+O7w9l5qaiptvvhmrVq3C5cuXcfnyZaxatQodOnRAampqvSdNRHaqq5fT0DRTOwKZeZ0Tt+uIiOrN4ZWmHj16ICYmBmvWrEGzZs0AANXV1XjyySeRkZGBo0ePumSino4rTdSgKvTWh/wCda829ftIqoHi8StEREaO/P12ODT5+fkhOzsbnTt3VlzPyclBz549jWfRNTUMTeR2lmfWxXwgdQy/3nadrOyctIrF7ToiakJcuj3Xq1cvYy2TuZMnT+LOO+909O2IyBlsNcBs0/f623WAtGp1cb/ttgTs70REZGRXR/AjR44Y/33GjBmYOXMmTp8+jT59+gAAvv/+e6xevRrLly93zSyJqG5ynRNgve1meV6d3JZgaBrQXAck3wsUHzGFqaor0moTC8aJiBTs2p7z8fGBSqXC9YaqVCpUV1c7bXLehNtz5HaWdU7m23X+UcA97wD7p5i26/yjgLvfANL+KgUmlVoKUq2jrbf64vbyWBYiapQc+ftt10pTbm6uUyZGRC5kfmadre06+e468zPrvntAGq9SS8EpYzzQe40pXFmeY8e6JyJqwuwKTfKxJUTkJWrbrpOD084+0jadLPZT4PAzUshKiZeuWZ5jx+06Imri7ApNls6fP4+0tDQUFRWhpqZG8dyMGTOcMjEiugHyeXW22hIA1nVOh58B7noF+G6M6Vpt/Z0AU90TEVET4nDLgfXr1+Pxxx+HRqNBq1atoFKpTG+mUuHMmTNOn6Q3YE0TeQVbbQnk3k3yFp05ub9TRgJQetZ2fydu2RGRF3Npn6bIyEg88cQTWLBgAXx8HO5Y0GgxNJHHq+34lYv7pDonuRg8dhOQNdO6v5N5obiMW3ZE5OVc2qeprKwMY8eOZWAi8ja2jl8pOycVf8uBKbgHEDa49v5OGeOloATwSBYianIcTj6JiYnYtGmTK+ZCRK4k1znF7TVtr5kHqaHpQNwe02qRZd2TSi0FpORBwIUM67vz2JKAiBo5h7fnqqurcd999+Hq1avo0aMHmjdvrnj+1VdfdeoEvQW358hr2dPf6eDfbdc9scaJiLyc0/s0mVu2bBl27NhhPHvOshCciLyMPf2dhqQo756T3fWKMjCxxomIGjGHQ9PKlSvx/vvv45FHHnHBdIjIrerq79R3o6lgXJb2kO0u4gDbEhBRo+NwTZNWq0W/fv1cMRcicjdbdU+AFIjkgvGAm4H+X5i26pJigfzNwK4Btdc48eBfImoEHA5NM2fOxJtvvumKuRCRJ9AEWwcexTl0qUDkA9IKkxycvhsj9XFSqaUVKcvAtWsgsGc4gxMReTWHt+f279+P3bt349tvv0X37t2tCsG/+OILp02OiDxAbVt2raOl41csu4hnjDeN45YdETUiDoemkJAQjBkz5voDiahxqO1IltJ86fgVc+ZtCXjwLxE1Mg63HCDb2HKAmhRHjmPxj5K28njwLxF5IJd2BCeiJs5WW4I2faV/Bna0Pr+utoN/2UWciLyMw9tzHTp0qLMfU1M9sJeoyXC0LcHV89I1Wwf/Whacc8uOiDyYw6Fp1qxZiseVlZU4fPgwtm/fjrlz5zprXkTkqeqqcTJvS9D3QyB9nFTTVJYHJP3RqqS2O+y4ZUdEHs7h0DRz5kyb11evXo2DBw/e8ISIyAuYdxEHau8kPjQN2NlHWm2Smd9h11wHGHKAjHHWd9hx5YmIPIzTapr+/Oc/4/PPP3fW2xGRNzE/+HdIinIVqbaDf3cNkFafkvpZN8Vkbyci8kAOrzTV5rPPPkPLli2d9XZE5E1sbdnJW25lebYP/i09a3q9+ZYdezsRkYdyODTdddddikJwIQQKCgpw4cIFvP32206dHBF5kRs5+Ffesov5gMXiROSxHA5No0ePVjz28fFBmzZtMGjQIHTp0sVZ8yIib+boHXbylh2LxYnIg7G5pZOwuSWRhQq97Tvs5JUm+Q47uSmmJfMVKstmmnF7le9LRFRPbG5JRO5nz8G/bfpKK0q1FYsnDwIuZEhF45bF4ubvy2JxImoAdm/P+fj41NnUEgBUKhWqqqrqHENETZStLTvz3k4qNRDUGagulWqauGVHRB7G7tC0efPmWp/LzMzEqlWrUFNT45RJEVEjZHmHneXKU9+PAF1noNJQd7H4kBTeZUdEbmF3aPrLX/5idS0nJwfz58/HN998g4SEBDz//PNOnRwRNTLmd9jVViyuCa67WDx5kPKAYFtbdkRELlCvmqbz589jypQp6NGjB6qqqpCdnY0NGzagffv2zp6fwvLly6FSqRRHuVy7dg3Tpk1Dq1atEBgYiAcffBCFhYWK1+Xl5WHkyJHw9/dHaGgo5s6da7WNmJKSgl69ekGr1eKWW27B+vXrXfpZiJo8eeUpbq/1lpv5cSxD000HAZtv2Vm2M5CxxomIXMSh0KTX6zFv3jzccsstOH78OJKTk/HNN9/g9ttvd9X8jA4cOIB///vfuOOOOxTXZ8+ejW+++QabNm3C3r17cf78eYwZM8b4fHV1NUaOHImKigpkZGRgw4YNWL9+PRYvXmwck5ubi5EjR2Lw4MHIzs7GrFmz8Nhjj2HHjh0u/1xETZq9xeJDUkzBydxdr5gCU4UeuLjfdidxBikicgZhp5deekm0bNlSdOvWTXz55Zf2vswprly5Im699VaRlJQkBg4cKGbOnCmEEKK4uFg0b95cbNq0yTj25MmTAoDIzMwUQgixdetW4ePjIwoKCoxj1qxZI3Q6nSgvLxdCCPHss8+K7t27K37nww8/LOLj4+2eo16vFwCEXq+v78ckovJiIbb3EeKrjkKU5Cmfu/C9EBvVQnwI089GtXS9vFiIrb1Mz3/VUYjSfOl1JXnS4+19pHFERGYc+ftt90rT/Pnzce3aNdxyyy3YsGEDxowZY/PHFaZNm4aRI0ciLi5OcT0rKwuVlZWK6126dEFUVBQyMzMBSEXqPXr0QFhYmHFMfHw8DAYDjh8/bhxj+d7x8fHG97ClvLwcBoNB8UNEN8jeLbv+X0hbdaJKqn3K+xQoPmLawuu7UaqZurjftHJVXiQViwNceSKierG7EHzixInXbTngCh9//DEOHTqEAwcOWD1XUFAAjUaDkJAQxfWwsDAUFBQYx5gHJvl5+bm6xhgMBly9ehV+fn5Wv3vZsmV47rnn6v25iKgW5sXiQO1HsgxNMxWL758qjZWDVPpYQB0AGHKkx5aHAbNNARHVg92hyR2F0fn5+Zg5cyaSkpLg6+vb4L+/LgsWLMCcOXOMjw0GAyIjI+t4BRHVS2132bWOBmI/Bb4zW+GO/RQ4/IyyXQEPAyYiJ/HojuBZWVkoKipCr169oFaroVarsXfvXqxatQpqtRphYWGoqKhAcXGx4nWFhYUIDw8HAISHh1vdTSc/vt4YnU5nc5UJALRaLXQ6neKHiFygri27w88oxx5+RioONyf3d7qQYb1ixTYFROQAjw5NQ4YMwdGjR5GdnW386d27NxISEoz/3rx5cyQnJxtfk5OTg7y8PMTExAAAYmJicPToURQVFRnHJCUlQafToVu3bsYx5u8hj5Hfg4jczPIuO8uz6OS2BCVngLSHlK+1bFPgH2XdpgBgnRMRXZfd23PuEBQUZNXOICAgAK1atTJeT0xMxJw5c9CyZUvodDo89dRTiImJQZ8+fQAAw4YNQ7du3TBhwgSsWLECBQUF+Mc//oFp06ZBq9UCAJ544gm89dZbePbZZ/Hoo49i9+7d+PTTT7Fly5aG/cBEdH211TiZN8RUqYHYTcDhp213FpfJhwoLYV3nVHZO2hrk9h0R/cGjQ5M9XnvtNfj4+ODBBx9EeXk54uPj8fbbbxufb9asGb799lv8/e9/R0xMDAICAjBp0iRF9/IOHTpgy5YtmD17Nt544w20a9cO7777LuLj493xkYioLrZqnMrOKc+wC+4BhA223Vn86nnp2qCtwL7HpMcAUJYn/bPqiukoFxaLE5EZlRBCuHsSjYHBYEBwcDD0ej3rm4hcTV4hkrfsKvRSQ8vyIttn2MmHAVfqgavnpNf4RgAqmEKTf5R0Rx5g0WBzL2ufiBoxR/5+e/1KExE1QZZtCRw5DDgpVlpVunbe+n3L8nmmHRHViqGJiBoHew8DHpoG7OxjWmECAL8IKUgl9ZMe11UszjonoiaLoYmIGh/LlSdLquv8T5/lGXcAm2ISkWe3HCAiqjfLNgWAKfiU5ZlaFfhHKVedAFOxeGm+8nWWx7EQUZPC0ERETYOtVgX+FttvfhFSgTjwx3ZdLJtiEpERQxMRNQ1ynZMcfFQq06qTf5Tp596d0j8BU52TZU8oImqSWNNERE2DZZ1ThV5ZLK5SmYq8bRWLx3zAwETUxDE0EVHTYX6HnaPF4pkTuNJE1MRxe46Imi57i8Xlc+2SB5mKw4moyWFoIiKS2SoWb9NX+qd5cCo7585ZEpGbMDQREcksi8XlrbiASFNw0oZK44ioyWFNExGRrK46p4BI6Rw6dgQnarIYmoiIzFmea2eO/ZmImjRuzxERERHZgaGJiIiIyA4MTURERER2YGgiIiIisgNDExEREZEdGJqIiIiI7MDQRERERGQHhiYiIiIiOzA0EREREdmBoYmIiIjIDgxNRERERHZgaCIiIiKyA0MTERERkR0YmoiIiIjswNBERFSXCj1Qds72c2XnpOeJqElgaCIiqk2FHtgzHNg1ECjNVz5Xmi9d3zOcwYmoiWBoIiKqTdUVoLwIKDkDJA8yBafi40BSrHS9vEgaJ+PqE1GjxdBERFQb/3bAkBQgsKMpOJ3fCWy/GyjLA/yjpOf920njufpE1KgxNBER1SUgUhmcUuKBmnLrcaX5UqiytfpERI0CQxMR0fUERAIxHyiv+UVIq03Jg4ALGcCuAVJgCuyoXH0CuGVH1Eio3T0BIiKPV5oPZE5QXlOppe25kjNAUj/Ttb4bpZBl/trkQYA2FBi8HdAEN9i0ici5uNJERFQX8223wI7A0HTpn2V5gKhSjhVVQMZ46TUVeuDifttbdlx5IvJKHh2ali1bhj/96U8ICgpCaGgoRo8ejZycHMWYa9euYdq0aWjVqhUCAwPx4IMPorCwUDEmLy8PI0eOhL+/P0JDQzF37lxUVSn/xy4lJQW9evWCVqvFLbfcgvXr17v64xGRpys7pwxMQ1KANn3/2H6LAq6eV45XqaWxuwZIq09J/ay37FgsTuS1PDo07d27F9OmTcP333+PpKQkVFZWYtiwYSgtLTWOmT17Nr755hts2rQJe/fuxfnz5zFmzBjj89XV1Rg5ciQqKiqQkZGBDRs2YP369Vi8eLFxTG5uLkaOHInBgwcjOzsbs2bNwmOPPYYdO3Y06OclIg+jDpK21eTQY77tJvPRAoN2SGNElRScSs8C+uOmx/KWHYvFibyaSggh3D0Je124cAGhoaHYu3cvBgwYAL1ejzZt2mDjxo34v//7PwDAjz/+iK5duyIzMxN9+vTBtm3bcN999+H8+fMICwsDAKxduxbz5s3DhQsXoNFoMG/ePGzZsgXHjh0z/q6xY8eiuLgY27dvt2tuBoMBwcHB0Ov10Ol0zv/wROQeFXop3MiF3WXnpJWikjPSatOgrUBId2UgshTYUSokz0iQApWtEFZ2TgpprHkialCO/P326JUmS3q9tJTdsmVLAEBWVhYqKysRFxdnHNOlSxdERUUhMzMTAJCZmYkePXoYAxMAxMfHw2Aw4Pjx48Yx5u8hj5Hfw5by8nIYDAbFDxE1Qppg5Z1w5qtPQ9OkwARIAajvRmllyZy8ZZfUTwpMtRWLc8uOyON5TWiqqanBrFmz0K9fP9x+++0AgIKCAmg0GoSEhCjGhoWFoaCgwDjGPDDJz8vP1TXGYDDg6tWrNuezbNkyBAcHG38iI20s2xNR46MJlu6Ci9trHXwyxktbcgE3mwrGWSxO1Gh4TWiaNm0ajh07ho8//tjdUwEALFiwAHq93viTn59//RcRUeNgufpkWTAelyoVjNe18sRicSKv4xV9mqZPn45vv/0WqampaNfO9D9U4eHhqKioQHFxsWK1qbCwEOHh4cYx+/fvV7yffHed+RjLO+4KCwuh0+ng5+dnc05arRZarfaGPxsRNQLylh1gqlUyX3lSqYGgzkB1qWmLrvSs6fXmW3bFx4GUEVJLA0BaeZLrnFj3RORWHr3SJITA9OnTsXnzZuzevRsdOnRQPH/33XejefPmSE5ONl7LyclBXl4eYmJiAAAxMTE4evQoioqKjGOSkpKg0+nQrVs34xjz95DHyO9BRFQnyy07y5WnoenAsHRpBaquLTuea0fk0Tx6pWnatGnYuHEjvvrqKwQFBRlrkIKDg+Hn54fg4GAkJiZizpw5aNmyJXQ6HZ566inExMSgT58+AIBhw4ahW7dumDBhAlasWIGCggL84x//wLRp04wrRU888QTeeustPPvss3j00Uexe/dufPrpp9iyZYvbPjsReRlNsGkFyNbKkzym70YgKVYZnOQtu5R46/et0AOGHCBjnOnOPHn1iStPRA3Ko1sOqFQqm9f/85//4JFHHgEgNbd8+umn8dFHH6G8vBzx8fF4++23jVtvAPDLL7/g73//O1JSUhAQEIBJkyZh+fLlUKtNmTElJQWzZ8/GiRMn0K5dOyxatMj4O+zBlgNEpGDZqgBQtiUIuBno+6F0PItlmwK/CKlxZsDNgDpACk2iStmqgMezEDmFI3+/PTo0eROGJiKqk3l/J/Pwc3Gf9cqTf9Qfr8kzXVOppRYHraOtj3aJ26sMZ0Rkt0bbp4mIyGvZ6i5uWSyu6y6tLtV1rt2FDOujXRiYiBqER9c0ERE1GnKxuLxlZ1ks3vcjQNcZqDRIK0/mq0yAskkmYCoUtzzahXVORC7DlSYiooZi3t/JcuWp9T3WQcfyXDtz5o8r9FJYsnWHHZtkEjkNV5qIiNzBcuUJMK0+yS0H5HPtbN1xd/W8dG3QVmDfY9JjQNnfqdLAYnEiJ2JoIiJyF/M2BYD9TTIr9cDVc1JA2j0MUMEUmuRtuwo9m2QSORlDExGRp6hP3dO189bvoz8JpN4P1JTbbpLJ1SeiemFoIiLyJPY2yRyaBuzsY1phAqT+TmV5tptkAspWBYBy9YmIrouhiYjIU9mqezJneRiwJTlEJQ8CYj4AMhKkM+9stSrglh3RdfHuOSIiT2Z+x51MXjEqyzOdbecfpVx1AqRQ5R9lalUgHxYsHw7Mu+6IHMKVJiIib2JZ5zQkxXqMX4QUjsrypH83JzfJHPC17bvurv5qOuvOsu6Jq1HUxDE0ERF5E8s6J5VKWiWS2xQAUlCKfld595zMeDjwCClAmd91N+BrIGMCUHzE1N7g6q/S9qAQ1gXkDFHUxDA0ERF5E8s6pwq9dYhSB0l32Ml8tFIgOvh3KTDJq1CWrpwyBSaVGvjTOuD7RPaAIvoDQxMRkbcxv8POkSaZQ1KUd8/J5ILx7x6QHqvUUnDa96j1atSQFPaAoiaLheBERN7Osljc/IiWoWlSYAKk4u++G69/113sp9Jry/Ksi8v1J4Htd5sC2ZAUZQ8oy4JyokaEoYmIqLGRV5/i9ioP9DXvLh5wc+133R1+BrjrFeU18x5QNeXK5yr0wMX9plWs8iJp9QngXXjUqHB7joioMbI8osWRu+5KzgBpD9X9/nKI2jUAUAdId9yJKtN7q4OkICXfhRf7CaDyMXU6VwdJ7yOHK8stPW7zkQdiaCIiagrsvevujn8CKX82FYPHbgKyZtq+C88/Sur9ZH6t70aguQ5IvtdUVC5qgNQHgMpi6fmM8UDzltIcrhWafvfg7dK/s+UBeSiGJiKipsCeu+4qDEDqKFNgCu4BBN2qfB97ekDdtVJ5F97dq4BDs/5oshkrXfevAkS11NJAdvVXtjwgj8bQRETUVFzvrju1WZDq+xGgDpRClKM9oCzvwjs0S6qRSnvILEi9DmTNUr7e8JN9LQ/YgJPchKGJiKipsqx7ckYPKHOxn0pF5SVngO/GSNfkICU/lsOYvS0P2ICT3Ih3zxERkYl5+wLLu/D820nhxLwH1PAsIGKY7VYGtu7C6/2W8nG/j6Qfc3W1PKitAefOftLWn3z33tVfpUJ0Wy0QeEcf1ZNKCCHcPYnGwGAwIDg4GHq9Hjqdzt3TISJyjQq9FELKi6TVp4BI0wHCcrfxoM5AdanpgGB5RQiwfmy+0iQL7CiFLXk1CpC2Bc0DlPw+/lHWq1GDtgKZE03hKrCjFPz825nmyk7m9AdH/n5zpYmIiOxnufpk2cpgaDowLB3o97Ep2KjUwD3vKB/3/0IKOGV5plWroenSe9jT8sCR1ai+G5WBybKXFJGdGJqIiMgx5lt45t3Hh6QAre+RwojcRFNeeTr+gumxqJKKwEW18n0DokzbfMZwtdnxBpzfPaD8XRnjgfM7Tdt35r2kys7Z3q7jFh7ZwEJwIiKqP5t34QUp78LzCwfSHpaaW1r2aVI1k8b5RUgtD8zDVl0tD+xdjZIL0VPipWvy0S/NddI2oxzG/CJMDThZUE61YGgiIqIbc7278ADl47i9tjuCA/a1PLC3Aae8GmVeGyXXU1VdkQKT/Bq5AWf5RelxXe0NLOfNTuZNBkMTERE5n60gJT82P1zYMlw4swGnrdWoq+elbTrLO/ZEDXCtwL72Bua9o2pboZKvAQxWjQhDExEReQ5nNeCsazWqLA9I6ieNtXX3nsxWQXlz3fVXqCyv2RusANNn5fl8HomhiYiIPFd9GnDaWo0KGwwMTQN29lEWlcsrTnKIApQF5YCyoDzmA+X8bK1Q9fsESPurY8FKG/rH3H+v+3w+rmq5FUMTERF5F0dXo3SdpXGVBusGnOnjrv/7zAvK7VmhMu9DBdgXrGqqAJ8/zvSr7Xw+e1e1bB18LAerulax5MfmY3g8jQJDExEReTd7CtHlHk3yNt497wD7p5hCi3+UtOqUPs6+gvK6VqjqE6x8/jiPr67z+ewJX4D1wcdysKosrn0Vy9ZKlxy2rhbcePiyZ4wXBDSGJiIianzMg5RlA84hKVJAsGS5ClVXQbk9K1SOBit7zuezZBm+AOuDj+9eJR2aXHKm9lUsWytdogZIGQkYfryx8FXfgOaBdyryGBUn4TEqREQeytbRL/I1edVG0wqovCwd/eJIe4O6VqhshR3L42CGpkv/NA9Wf1oLHHii7jGW72Prd8nhSz6WxnwVK/ZTaRXL/HNYrnT96W3gwJPKLu5y+FIcY2MWvnwjTOHLkTEBN0tF/XJAC+wIDPzG+k5FuW+WE4/DceTvN1eaiIiocbO1XWd+DZBWUeQGnENS6mhvcJv1+9taoRKwL1jZWrE6OP36YyzZWtUyr8WyZxXLcsz+qcrHh2ZZhy/LLUR7thltjen+/5QBzdadioD0n1elwbRyKF9roNUmrjQ5CVeaiIi8XIVeGazMV6jkgnLg+itUmlZAxQVp+wiQrsduUtYeycHqmll9kmWQsLUa5Miqlq2Dj+1ZxbIc0/8LU/iS2XPwcn3GmK+OxXyg/Kzy58+coNxqDYjEjXDk7zdDk4XVq1fj5ZdfRkFBAe688068+eabuOeee677OoYmIqJGyDJImV8DTCtU8tafSmW65kiwsmdby97wZR4sagslMnuCjLPCV30DWm2BcEjKDQcmgKGp3j755BNMnDgRa9euRXR0NF5//XVs2rQJOTk5CA0NrfO1DE1ERE2UM4KVPQXU9q5qDUsHyn41FXSr1MCf1gAH/u5YTZP59p4zwld9A5qtsDU0HWjT1+o/ivpgaKqn6Oho/OlPf8Jbb70FAKipqUFkZCSeeuopzJ8/XzG2vLwc5eXlxscGgwGRkZEMTUREZO16wcqeW/XtCV9+EUD0e1Itlhx2gjoD1aVS2HKkODuwI9DrdSnA3Gj4upGAxpUmz1NRUQF/f3989tlnGD16tPH6pEmTUFxcjK+++koxfunSpXjuuees3oehiYiIXMbe8GVei+UXbgpbjrQBUAebVrZuJHzVN6DVdqeiG2uaePfcHy5evIjq6mqEhYUproeFheHHH3+0Gr9gwQLMmTPH+FheaSIiInIZy0aetV2zvFvQ/HHc3us3nIzbq7yj0Dx8qXysw5eqmfR6OXz5qB0bow4GsmZc/07FgCgpKMl3zyUPkuZqHiJdiKGpnrRaLbRarbunQUREZM1Wl3T5sXnAsBXAzMc4I3zVJ6DJdyr6RZjm5hdhamY5JMXUp0l+vwbA0PSH1q1bo1mzZigsLFRcLywsRHh4uJtmRURE5EbOCl/2jLEMaObXAGX374BIUyBrwI7gPg32mzycRqPB3XffjeTkZOO1mpoaJCcnIyYmxo0zIyIiagI0wdbbbPI1/3bW4cjWNRfjSpOZOXPmYNKkSejduzfuuecevP766ygtLcXkyZPdPTUiIiJyM4YmMw8//DAuXLiAxYsXo6CgAD179sT27dutisOJiIio6WHLASdhc0siIiLv48jfb9Y0EREREdmBoYmIiIjIDgxNRERERHZgaCIiIiKyA0MTERERkR0YmoiIiIjswD5NTiJ3bjAYDG6eCREREdlL/rttTwcmhiYnuXJFOhsnMjLSzTMhIiIiR125cgXBwXUfy8Lmlk5SU1OD8+fPIygoCCqVyqnvbTAYEBkZifz8fDbOdCF+zw2D33PD4PfcMPg9NxxXfddCCFy5cgURERHw8am7aokrTU7i4+ODdu3aXX/gDdDpdPw/ygbA77lh8HtuGPyeGwa/54bjiu/6eitMMhaCExEREdmBoYmIiIjIDgxNXkCr1WLJkiXQarXunkqjxu+5YfB7bhj8nhsGv+eG4wnfNQvBiYiIiOzAlSYiIiIiOzA0EREREdmBoYmIiIjIDgxNRERERHZgaPIQq1evxs033wxfX19ER0dj//79dY7ftGkTunTpAl9fX/To0QNbt25toJl6N0e+53feeQf9+/dHixYt0KJFC8TFxV33PxeSOPrfZ9nHH38MlUqF0aNHu3aCjYSj33NxcTGmTZuGtm3bQqvV4rbbbuP/dtjB0e/59ddfR+fOneHn54fIyEjMnj0b165da6DZeqfU1FSMGjUKERERUKlU+PLLL6/7mpSUFPTq1QtarRa33HIL1q9f7/J5QpDbffzxx0Kj0Yj3339fHD9+XEyZMkWEhISIwsJCm+PT09NFs2bNxIoVK8SJEyfEP/7xD9G8eXNx9OjRBp65d3H0ex4/frxYvXq1OHz4sDh58qR45JFHRHBwsDh37lwDz9y7OPo9y3Jzc8VNN90k+vfvL/7yl780zGS9mKPfc3l5uejdu7cYMWKESEtLE7m5uSIlJUVkZ2c38My9i6Pf84cffii0Wq348MMPRW5urtixY4do27atmD17dgPP3Lts3bpVLFy4UHzxxRcCgNi8eXOd48+cOSP8/f3FnDlzxIkTJ8Sbb74pmjVrJrZv3+7SeTI0eYB77rlHTJs2zfi4urpaREREiGXLltkc/9BDD4mRI0cqrkVHR4vHH3/cpfP0do5+z5aqqqpEUFCQ2LBhg6um2CjU53uuqqoSffv2Fe+++66YNGkSQ5MdHP2e16xZIzp27CgqKioaaoqNgqPf87Rp08S9996ruDZnzhzRr18/l86zMbEnND377LOie/fuimsPP/ywiI+Pd+HMhOD2nJtVVFQgKysLcXFxxms+Pj6Ii4tDZmamzddkZmYqxgNAfHx8reOpft+zpbKyMlRWVqJly5aumqbXq+/3/PzzzyM0NBSJiYkNMU2vV5/v+euvv0ZMTAymTZuGsLAw3H777XjxxRdRXV3dUNP2OvX5nvv27YusrCzjFt6ZM2ewdetWjBgxokHm3FS46+8gD+x1s4sXL6K6uhphYWGK62FhYfjxxx9tvqagoMDm+IKCApfN09vV53u2NG/ePERERFj9HyqZ1Od7TktLw3vvvYfs7OwGmGHjUJ/v+cyZM9i9ezcSEhKwdetWnD59Gk8++SQqKyuxZMmShpi216nP9zx+/HhcvHgRsbGxEEKgqqoKTzzxBP7f//t/DTHlJqO2v4MGgwFXr16Fn5+fS34vV5qI7LB8+XJ8/PHH2Lx5M3x9fd09nUbjypUrmDBhAt555x20bt3a3dNp1GpqahAaGop169bh7rvvxsMPP4yFCxdi7dq17p5ao5KSkoIXX3wRb7/9Ng4dOoQvvvgCW7ZswT//+U93T42cgCtNbta6dWs0a9YMhYWFiuuFhYUIDw+3+Zrw8HCHxlP9vmfZK6+8guXLl2PXrl244447XDlNr+fo9/zzzz/j7NmzGDVqlPFaTU0NAECtViMnJwedOnVy7aS9UH3++9y2bVs0b94czZo1M17r2rUrCgoKUFFRAY1G49I5e6P6fM+LFi3ChAkT8NhjjwEAevTogdLSUkydOhULFy6Ejw/XKpyhtr+DOp3OZatMAFea3E6j0eDuu+9GcnKy8VpNTQ2Sk5MRExNj8zUxMTGK8QCQlJRU63iq3/cMACtWrMA///lPbN++Hb17926IqXo1R7/nLl264OjRo8jOzjb+3H///Rg8eDCys7MRGRnZkNP3GvX573O/fv1w+vRpYygFgJ9++glt27ZlYKpFfb7nsrIyq2AkB1XBo16dxm1/B11aZk52+fjjj4VWqxXr168XJ06cEFOnThUhISGioKBACCHEhAkTxPz5843j09PThVqtFq+88oo4efKkWLJkCVsO2MHR73n58uVCo9GIzz77TPz222/GnytXrrjrI3gFR79nS7x7zj6Ofs95eXkiKChITJ8+XeTk5Ihvv/1WhIaGin/961/u+ghewdHvecmSJSIoKEh89NFH4syZM2Lnzp2iU6dO4qGHHnLXR/AKV65cEYcPHxaHDx8WAMSrr74qDh8+LH755RchhBDz588XEyZMMI6XWw7MnTtXnDx5UqxevZotB5qSN998U0RFRQmNRiPuuece8f333xufGzhwoJg0aZJi/Keffipuu+02odFoRPfu3cWWLVsaeMbeyZHvuX379gKA1c+SJUsafuJextH/PptjaLKfo99zRkaGiI6OFlqtVnTs2FG88MILoqqqqoFn7X0c+Z4rKyvF0qVLRadOnYSvr6+IjIwUTz75pLh8+XLDT9yL7Nmzx+b/3srf7aRJk8TAgQOtXtOzZ0+h0WhEx44dxX/+8x+Xz1MlBNcLiYiIiK6HNU1EREREdmBoIiIiIrIDQxMRERGRHRiaiIiIiOzA0ERERERkB4YmIiIiIjswNBERERHZgaGJiIiIyA4MTUTk9VJSUqBSqVBcXNygv3f9+vUICQm5ofc4e/YsVCoVsrOzax3jrs9HREoMTUTk0VQqVZ0/S5cudfcUiaiJULt7AkREdfntt9+M//7JJ59g8eLFyMnJMV4LDAzEwYMHHX7fiooKaDQap8yRiJoGrjQRkUcLDw83/gQHB0OlUimuBQYGGsdmZWWhd+/e8Pf3R9++fRXhaunSpejZsyfeffdddOjQAb6+vgCA4uJiPPbYY2jTpg10Oh3uvfde/PDDD8bX/fDDDxg8eDCCgoKg0+lw9913W4W0HTt2oGvXrggMDMTw4cMVQa+mpgbPP/882rVrB61Wi549e2L79u11fuatW7fitttug5+fHwYPHoyzZ8/eyFdIRE7C0EREjcbChQuxcuVKHDx4EGq1Go8++qji+dOnT+Pzzz/HF198Yawh+utf/4qioiJs27YNWVlZ6NWrF4YMGYJLly4BABISEtCuXTscOHAAWVlZmD9/Ppo3b258z7KyMrzyyiv44IMPkJqairy8PDzzzDPG59944w2sXLkSr7zyCo4cOYL4+Hjcf//9OHXqlM3PkJ+fjzFjxmDUqFHIzs7GY489hvnz5zv5myKiehFERF7iP//5jwgODra6vmfPHgFA7Nq1y3hty5YtAoC4evWqEEKIJUuWiObNm4uioiLjmO+++07odDpx7do1xft16tRJ/Pvf/xZCCBEUFCTWr19f63wAiNOnTxuvrV69WoSFhRkfR0REiBdeeEHxuj/96U/iySefFEIIkZubKwCIw4cPCyGEWLBggejWrZti/Lx58wQAcfnyZZvzIKKGwZUmImo07rjjDuO/t23bFgBQVFRkvNa+fXu0adPG+PiHH35ASUkJWrVqhcDAQONPbm4ufv75ZwDAnDlz8NhjjyEuLg7Lly83Xpf5+/ujU6dOit8r/06DwYDz58+jX79+itf069cPJ0+etPkZTp48iejoaMW1mJgYu78DInIdFoITUaNhvm2mUqkASDVFsoCAAMX4kpIStG3bFikpKVbvJbcSWLp0KcaPH48tW7Zg27ZtWLJkCT7++GM88MADVr9T/r1CCGd8HCLyMFxpIqImq1evXigoKIBarcYtt9yi+GndurVx3G233YbZs2dj586dGDNmDP7zn//Y9f46nQ4RERFIT09XXE9PT0e3bt1svqZr167Yv3+/4tr333/v4CcjIldgaCKiJisuLg4xMTEYPXo0du7cibNnzyIjIwMLFy7EwYMHcfXqVUyfPh0pKSn45ZdfkJ6ejgMHDqBr1652/465c+fipZdewieffIKcnBzMnz8f2dnZmDlzps3xTzzxBE6dOoW5c+ciJycHGzduxPr16530iYnoRnB7joiaLJVKha1bt2LhwoWYPHkyLly4gPDwcAwYMABhYWFo1qwZfv/9d0ycOBGFhYVo3bo1xowZg+eee87u3zFjxgzo9Xo8/fTTKCoqQrdu3fD111/j1ltvtTk+KioKn3/+OWbPno0333wT99xzD1588UWrOwGJqOGpBDffiYiIiK6L23NEREREdmBoIiIiIrIDQxMRERGRHRiaiIiIiOzA0ERERERkB4YmIiIiIjswNBERERHZgaGJiIiIyA4MTURERER2YGgiIiIisgNDExEREZEd/j/IddSWuvEWsAAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -390,19 +491,20 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "thresh = np.linspace(0.0,1.0,50)\n",
-    "probs = notNone_df.prob.to_numpy()\n",
-    "condition = (probs>0.5)\n",
-    "filtered_probs = probs[condition]\n",
-    "num_compounds = [len(probs[(probs>t)]) for t in thresh]\n",
+    "# Create a numpy array of 100 threshold values\n",
+    "thresh = np.linspace(0.0, 1.0, 100)\n",
     "\n",
-    "fig,ax = plt.subplots()\n",
+    "# Use a list comprehension to generate a list of the number of compounds as a function of the probability threshold\n",
+    "num_compounds = [len(probs[(probs >= t)]) for t in thresh]\n",
     "\n",
-    "ax.scatter(x=thresh, y=num_compounds, marker='x')\n",
+    "# Set up the figure and plot the number of compounds against the threshold\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "ax.scatter(x=thresh, y=num_compounds, marker='x', color='orange')\n",
     "plt.xlabel('Threshold')\n",
     "plt.ylabel('Number of compounds')\n",
-    "ax.axvline()\n",
-    "plt.show()"
+    "\n",
+    "plt.show()\n"
    ]
   }
  ],

--- a/examples/Oxidation_states/oxidation_states.ipynb
+++ b/examples/Oxidation_states/oxidation_states.ipynb
@@ -23,7 +23,8 @@
     "import re\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "import pandas as pd\n"
+    "import pandas as pd\n",
+    "from pymatgen.core import Composition"
    ]
   },
   {
@@ -62,7 +63,7 @@
      "output_type": "stream",
      "text": [
       "The species included in the probability table for the oxidation states model are show below \n",
-      "['Cl-1', 'O-2', 'I-1', 'S-2', 'Te-2', 'Br-1', 'F-1', 'Se-2', 'U5', 'Pb2', 'Sr2', 'Sc3', 'Eu3', 'Yb2', 'Gd3', 'Ni3', 'Tl1', 'Re7', 'Ti4', 'Y2', 'Hg2', 'Ce4', 'Nb5', 'Ce2', 'Y1', 'Ta5', 'Fe2', 'W4', 'Mo6', 'Cr6', 'Pd4', 'Al3', 'Ag3', 'Sn4', 'Cr2', 'Hf2', 'Tl3', 'Ge3', 'Mn5', 'Eu2', 'Mo5', 'Ge2', 'Pr2', 'Ni1', 'V5', 'La2', 'Sm3', 'Tb4', 'Hf4', 'U3', 'Ga2', 'Mo3', 'Mg2', 'Li1', 'Ge4', 'Ca2', 'Nb1', 'Ru4', 'Pb4', 'Ti2', 'Tm3', 'Mn2', 'Zr2', 'Pd3', 'Sc2', 'Be2', 'Sb3', 'W2', 'In1', 'Nb3', 'Mn7', 'Bi1', 'Cs1', 'Tb1', 'Er3', 'Ni2', 'Ru3', 'Cr3', 'Cr4', 'Ga1', 'Nb4', 'Re6', 'Zn2', 'Sb4', 'Fe3', 'Zr3', 'Rh4', 'U2', 'Th4', 'Na1', 'Th3', 'Ir3', 'Co1', 'Ir5', 'In3', 'V2', 'Ta1', 'Ga3', 'Fe1', 'Pr3', 'Ta2', 'V4', 'Sb5', 'Nb2', 'Lu3', 'Hg1', 'Gd2', 'Tb3', 'Sn3', 'W6', 'Ce3', 'Cd2', 'W3', 'Ta4', 'Ta3', 'Rh1', 'Dy2', 'Ho2', 'Cr5', 'K1', 'Mn3', 'Re2', 'Ag2', 'Fe4', 'Yb3', 'Ag1', 'In2', 'Ru5', 'U4', 'Y3', 'Co2', 'Nd3', 'Sc1', 'V3', 'Co4', 'Cu1', 'Co3', 'La1', 'Nd2', 'Cu3', 'Re4', 'Ir4', 'Ti3', 'Pd2', 'Zr1', 'Sm2', 'W5', 'Bi3', 'Ba2', 'Ni4', 'Dy3', 'Mo4', 'Ho3', 'U6', 'Mo2', 'Ru6', 'Re5', 'Mn1', 'Bi5', 'Mn4', 'Zr4', 'Ru2', 'Rh3', 'Cu2', 'Sn2', 'Tm2', 'Re3', 'Mn6', 'La3', 'Bi2', 'Rb1', 'Tb2', 'Ir6']\n"
+      "['F-1', 'I-1', 'O-2', 'Cl-1', 'S-2', 'Se-2', 'Br-1', 'Te-2', 'Mn5', 'Fe3', 'U6', 'Nb1', 'Cr4', 'Pr2', 'Re4', 'Cu2', 'Sr2', 'Sc1', 'Sb5', 'Eu3', 'Mn1', 'Ag2', 'Cs1', 'Al3', 'V5', 'Ta2', 'Dy3', 'Rb1', 'Ta4', 'La2', 'Rh4', 'Lu3', 'Nd2', 'Tm2', 'Y1', 'Re2', 'Th4', 'Co1', 'Mn2', 'Mn3', 'Ni4', 'Pb4', 'Sc3', 'W2', 'Ta3', 'Mo4', 'Ru2', 'Ru3', 'Ce3', 'Gd2', 'Tl3', 'Ir6', 'Zr4', 'Ga1', 'Sn4', 'Mn6', 'La3', 'Pr3', 'Ti2', 'Bi2', 'Tb1', 'Pd4', 'Ru5', 'Eu2', 'Pb2', 'Nd3', 'Ru6', 'Cr6', 'Hf4', 'Zr2', 'Ho3', 'Ce4', 'Ce2', 'Ge3', 'Th3', 'Mg2', 'Re3', 'Co4', 'Ni1', 'Ni2', 'Ir3', 'Gd3', 'In2', 'Y3', 'U4', 'Re5', 'Ir4', 'Mo2', 'Sn3', 'Cu3', 'Ti3', 'Tb2', 'Pd3', 'Bi5', 'Y2', 'U3', 'Ge4', 'Mo3', 'Zr3', 'Er3', 'Sm2', 'Sm3', 'Cr2', 'Sb3', 'Mo6', 'Be2', 'Ta5', 'V3', 'Rh1', 'Pd2', 'Dy2', 'Cd2', 'Sn2', 'Tb4', 'Co3', 'Re6', 'Yb3', 'W3', 'Mo5', 'Re7', 'Hf2', 'Fe2', 'Ag1', 'Ir5', 'Nb5', 'Yb2', 'Li1', 'Tl1', 'Zr1', 'Zn2', 'Sb4', 'Ti4', 'Ba2', 'Co2', 'V4', 'Nb2', 'U2', 'Bi1', 'W4', 'Na1', 'Nb4', 'Ho2', 'Nb3', 'Ge2', 'Mn4', 'Ru4', 'Ca2', 'In1', 'U5', 'Ag3', 'In3', 'V2', 'W6', 'Fe4', 'Ni3', 'Tm3', 'Ga3', 'Hg1', 'Sc2', 'Cr3', 'Ta1', 'Cu1', 'Bi3', 'K1', 'Ga2', 'Rh3', 'W5', 'Fe1', 'La1', 'Mn7', 'Hg2', 'Cr5', 'Tb3']\n"
      ]
     }
    ],
@@ -240,11 +241,11 @@
       "Number of compositions: 14832\n",
       "Each list entry looks like this:\n",
       "  elements, oxidation states, stoichiometries\n",
-      "['Sc', 'Ni', 'F'] (3, 3, -1) (1, 1, 6)\n",
-      "['Sc', 'Ni', 'Cl'] (3, 3, -1) (1, 1, 6)\n",
-      "['Sc', 'Ni', 'Br'] (3, 3, -1) (1, 1, 6)\n",
-      "['Sc', 'Ni', 'I'] (3, 3, -1) (1, 1, 6)\n",
-      "['Sc', 'Ti', 'F'] (3, 4, -1) (1, 1, 7)\n"
+      "['Mn', 'Fe', 'F'] (5, 3, -1) (1, 1, 8)\n",
+      "['Mn', 'Fe', 'Cl'] (5, 3, -1) (1, 1, 8)\n",
+      "['Mn', 'Fe', 'Br'] (5, 3, -1) (1, 1, 8)\n",
+      "['Mn', 'Fe', 'I'] (5, 3, -1) (1, 1, 8)\n",
+      "['Mn', 'Nb', 'F'] (5, 1, -1) (1, 1, 6)\n"
      ]
     }
    ],
@@ -285,18 +286,16 @@
      "output_type": "stream",
      "text": [
       "Each list entry now looks like this: \n",
-      "ScNiF6\n",
-      "ScNiCl6\n",
-      "ScNiBr6\n",
-      "ScNiI6\n",
-      "ScTiF7\n"
+      "MnFeF8\n",
+      "MnFeCl8\n",
+      "MnFeBr8\n",
+      "MnFeI8\n",
+      "MnNbF6\n"
      ]
     }
    ],
    "source": [
     "# Get the formulas for the compositions\n",
-    "from pymatgen.core import Composition\n",
-    "\n",
     "\n",
     "def comp_maker(comp):\n",
     "    form = []\n",
@@ -372,43 +371,43 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>ScNiF6</td>\n",
-       "      <td>Sc3+</td>\n",
-       "      <td>Ni3+</td>\n",
+       "      <td>MnFeF8</td>\n",
+       "      <td>Mn5+</td>\n",
+       "      <td>Fe3+</td>\n",
        "      <td>F1-</td>\n",
-       "      <td>0.567797</td>\n",
+       "      <td>0.383333</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>ScNiCl6</td>\n",
-       "      <td>Sc3+</td>\n",
-       "      <td>Ni3+</td>\n",
+       "      <td>MnFeCl8</td>\n",
+       "      <td>Mn5+</td>\n",
+       "      <td>Fe3+</td>\n",
        "      <td>Cl1-</td>\n",
-       "      <td>0.318182</td>\n",
+       "      <td>0.281250</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>ScNiBr6</td>\n",
-       "      <td>Sc3+</td>\n",
-       "      <td>Ni3+</td>\n",
+       "      <td>MnFeBr8</td>\n",
+       "      <td>Mn5+</td>\n",
+       "      <td>Fe3+</td>\n",
        "      <td>Br1-</td>\n",
-       "      <td>0.250000</td>\n",
+       "      <td>0.277778</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>ScNiI6</td>\n",
-       "      <td>Sc3+</td>\n",
-       "      <td>Ni3+</td>\n",
+       "      <td>MnFeI8</td>\n",
+       "      <td>Mn5+</td>\n",
+       "      <td>Fe3+</td>\n",
        "      <td>I1-</td>\n",
-       "      <td>0.250000</td>\n",
+       "      <td>0.100000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>ScTiF7</td>\n",
-       "      <td>Sc3+</td>\n",
-       "      <td>Ti4+</td>\n",
+       "      <td>MnNbF6</td>\n",
+       "      <td>Mn5+</td>\n",
+       "      <td>Nb1+</td>\n",
        "      <td>F1-</td>\n",
-       "      <td>0.803922</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -416,11 +415,11 @@
       ],
       "text/plain": [
        "  formula_pretty     A     B     X  compound_probability\n",
-       "0         ScNiF6  Sc3+  Ni3+   F1-              0.567797\n",
-       "1        ScNiCl6  Sc3+  Ni3+  Cl1-              0.318182\n",
-       "2        ScNiBr6  Sc3+  Ni3+  Br1-              0.250000\n",
-       "3         ScNiI6  Sc3+  Ni3+   I1-              0.250000\n",
-       "4         ScTiF7  Sc3+  Ti4+   F1-              0.803922"
+       "0         MnFeF8  Mn5+  Fe3+   F1-              0.383333\n",
+       "1        MnFeCl8  Mn5+  Fe3+  Cl1-              0.281250\n",
+       "2        MnFeBr8  Mn5+  Fe3+  Br1-              0.277778\n",
+       "3         MnFeI8  Mn5+  Fe3+   I1-              0.100000\n",
+       "4         MnNbF6  Mn5+  Nb1+   F1-              0.000000"
       ]
      },
      "execution_count": 10,
@@ -488,8 +487,6 @@
     }
    ],
    "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
     "\n",
     "# Create a numpy array of 100 threshold values\n",
     "thresh = np.linspace(0.0, 1.0, 100)\n",
@@ -510,7 +507,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('m3gnet')",
+   "display_name": "Python 3.8.13 ('smact_tests')",
    "language": "python",
    "name": "python3"
   },
@@ -524,12 +521,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.8.13"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "12ffb9a1fc55ed07279e7dd77ad285a3497c27b3c474e4f9eb992cd6013b4b31"
+    "hash": "9f89bce96645c075fd87ba4308874c26726cf41cb3962e47a97b7697a60dd355"
    }
   }
  },

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,7 +48,7 @@ The distorter module uses the [ASE Python library](https://wiki.fysik.dtu.dk/ase
  Usually, the perovskite structure contains an A cationm, a B cation and an X anion in the ratio 1:1:3 ([see wikipeidia for more information](https://en.wikipedia.org/wiki/Perovskite_(structure))).
  Here we search for charge inverted perovskites, i.e. with an anion on the A site. This class of material is closely related to perovskites, and may represent another fruitful search space for new photovoltaic materials.
 
-In this example  we assume a simple [formate moelcule](https://en.wikipedia.org/wiki/Formate) as the C-site and uses [Goldschmidt ratio rules](https://en.wikipedia.org/wiki/Goldschmidt_tolerance_factor) as part of the screening.
+In this example  we assume a simple [formate molecule](https://en.wikipedia.org/wiki/Formate) as the C-site and uses [Goldschmidt ratio rules](https://en.wikipedia.org/wiki/Goldschmidt_tolerance_factor) as part of the screening.
 These rules allow us to estimate whether or not a perovskite structure is likely to form based on data about ionic size alone.
 We also apply the standard charge neutrality and electronegativity tests as described [in the docs](https://smact.readthedocs.io/en/latest/examples.html#neutral-combinations).
 
@@ -66,3 +66,6 @@ The notebooks involve setting up a database of SMACT compatible structures, gene
 
 ### Dopant prediction
 Contains an example of using the dopant prediction submodule.
+
+### Oxidation states
+Contains an example of using the `smact.oxidation_states` submodule to predict the likelihood of metal cations coexisting with halide anions in ternary compounds based on a statistical analysis of oxidation states. Full details of the oxidation states model can be found in [this publication](https://pubs.rsc.org/en/content/articlelanding/2018/FD/C8FD00032H).


### PR DESCRIPTION
- An example notebooks has been added `examples/Oxidation_states/oxidation_states.ipynb` to demonstrate the usage of the oxidation states model
- The `examples/README.md` has been updated to reference the oxidation states model example.

@dandavies99 I tried to replicate the results from the Faraday Discussion paper [Materials discovery by chemical analogy: role of oxidation states in structure prediction](https://pubs.rsc.org/en/content/articlelanding/2018/fd/c8fd00032h) following the methodology for creating the ternary metal halide search space, but I seem to underestimating the space. Would you be able to look into this for this example notebook?