### PR TITLE
Dopant prediction docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -385,6 +385,7 @@ MOCK_MODULES = [
   'pymatgen.core.periodic_table',
   'pymatgen.ext.matproj',
   'pymatgen.util',
+  'pymatgen.util.plotting',
   'pymatgen.analysis.structure_prediction'
 ]
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -384,6 +384,7 @@ MOCK_MODULES = [
   'pymatgen.core',
   'pymatgen.core.periodic_table',
   'pymatgen.ext.matproj',
-  'pymatgen.util'
+  'pymatgen.util',
+  'pymatgen.analysis.structure_prediction'
 ]
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -383,6 +383,7 @@ MOCK_MODULES = [
   'pymatgen.analysis.structure_prediction',
   'pymatgen.core',
   'pymatgen.core.periodic_table',
-  'pymatgen.ext.matproj'
+  'pymatgen.ext.matproj',
+  'pymatgen.util'
 ]
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/smact/dopant_prediction/doper.py
+++ b/smact/dopant_prediction/doper.py
@@ -2,13 +2,14 @@ from smact.structure_prediction import mutation, utilities
 import smact
 import re
 from pymatgen.util import plotting
+from typing import Tuple
 
 class Doper:
     '''
     A class to search for n and p type dopants
     Methods: get_dopants, plot_dopants
     '''
-    def __init__(self, original_species: tuple[str], 
+    def __init__(self, original_species: Tuple[str], 
                   num_dopants=5
                   #match_oxi_sign=False):
                 ):


### PR DESCRIPTION
Resolved issue with the docs for `smact.dopant_prediction`. 
They now appear on readthedocs