### PR TITLE
Mp api updates

### DIFF
--- a/smact/structure_prediction/database.py
+++ b/smact/structure_prediction/database.py
@@ -19,7 +19,7 @@ from pymatgen.ext.matproj import MPRester
 
 from . import logger
 from .structure import SmactStructure
-from .utilities import get_sign, convert_next_gen_mprest_data
+from .utilities import convert_next_gen_mprest_data, get_sign
 
 
 class StructureDB:
@@ -121,10 +121,9 @@ class StructureDB:
                     )
                 except NotImplementedError:
                     docs = m.summary.search(
-                        theoretical=False,
-                        fields=["structure","material_id"]
+                        theoretical=False, fields=["structure", "material_id"]
                     )
-                    data=[convert_next_gen_mprest_data(doc) for doc in docs]
+                    data = [convert_next_gen_mprest_data(doc) for doc in docs]
         else:
             data = mp_data
 
@@ -276,7 +275,7 @@ def parse_mprest(
     """
     # Convert next gen query data to a dic
     # TODO check if the data is the same type as MPDataDoc
-    if not isinstance(data,dict):
+    if not isinstance(data, dict):
         data = convert_next_gen_mprest_data(data)
 
     try:

--- a/smact/structure_prediction/structure.py
+++ b/smact/structure_prediction/structure.py
@@ -16,7 +16,7 @@ from pymatgen.ext.matproj import MPRester
 import smact
 
 from . import logger
-from .utilities import get_sign, convert_next_gen_mprest_data
+from .utilities import convert_next_gen_mprest_data, get_sign
 
 
 class SmactStructure:
@@ -277,7 +277,7 @@ class SmactStructure:
                 )
             except NotImplementedError:
                 # New API routine
-                docs = m.summary.search(formula=formula,fields=['structure'])
+                docs = m.summary.search(formula=formula, fields=["structure"])
                 structs = [convert_next_gen_mprest_data(doc) for doc in docs]
 
             if len(structs) == 0:

--- a/smact/structure_prediction/structure.py
+++ b/smact/structure_prediction/structure.py
@@ -269,10 +269,16 @@ class SmactStructure:
         with MPRester(api_key) as m:
             eles = SmactStructure._get_ele_stoics(sanit_species)
             formula = "".join(f"{ele}{stoic}" for ele, stoic in eles.items())
-            structs = m.query(
-                criteria={"reduced_cell_formula": formula},
-                properties=["structure"],
-            )
+            try:
+                # Legacy API routine
+                structs = m.query(
+                    criteria={"reduced_cell_formula": formula},
+                    properties=["structure"],
+                )
+            except NotImplementedError:
+                # New API routine
+                docs = m.summary.search(formula=formula,fields=['structure'])
+                structs = [doc.dict(exclude={"fields_not_requested"}) for doc in docs]
 
             if len(structs) == 0:
                 raise ValueError(

--- a/smact/structure_prediction/structure.py
+++ b/smact/structure_prediction/structure.py
@@ -16,7 +16,7 @@ from pymatgen.ext.matproj import MPRester
 import smact
 
 from . import logger
-from .utilities import get_sign
+from .utilities import get_sign, convert_next_gen_mprest_data
 
 
 class SmactStructure:
@@ -278,7 +278,7 @@ class SmactStructure:
             except NotImplementedError:
                 # New API routine
                 docs = m.summary.search(formula=formula,fields=['structure'])
-                structs = [doc.dict(exclude={"fields_not_requested"}) for doc in docs]
+                structs = [convert_next_gen_mprest_data(doc) for doc in docs]
 
             if len(structs) == 0:
                 raise ValueError(

--- a/smact/structure_prediction/utilities.py
+++ b/smact/structure_prediction/utilities.py
@@ -1,8 +1,9 @@
 """Miscellaneous tools for data parsing."""
 
 import re
-from typing import Tuple
-
+from typing import Tuple, Dict, Union, Optional
+import pymatgen
+from . import logger
 
 def parse_spec(species: str) -> Tuple[str, int]:
     """Parse a species string into its element and charge.
@@ -69,3 +70,19 @@ def get_sign(charge: int) -> str:
         return "-"
     else:
         return ""
+
+def convert_next_gen_mprest_data(doc) -> Dict[str,Union[pymatgen.core.Structure,Optional[str]]]:
+    """ Converts the `MPDataDoc` object returned by a next-gen MP query to a dictionary
+    
+    Args:
+        doc (MPDataDoc): A MPDataDoc object (based on a pydantic model) with fields 'structure' and 'material_id'
+    Returns:
+        A dictionary containing at least the keys 'structure' and
+        'material_id', with the associated values.
+
+    """
+    try:
+       return doc.dict(exclude={'fields_not_requested'})
+    except:
+        logger.warn(f'Could not convert input:\n {doc}\n to a dictionary.')
+        raise TypeError("Input is not an MPDataDoc object.")

--- a/smact/structure_prediction/utilities.py
+++ b/smact/structure_prediction/utilities.py
@@ -1,9 +1,12 @@
 """Miscellaneous tools for data parsing."""
 
 import re
-from typing import Tuple, Dict, Union, Optional
+from typing import Dict, Optional, Tuple, Union
+
 import pymatgen
+
 from . import logger
+
 
 def parse_spec(species: str) -> Tuple[str, int]:
     """Parse a species string into its element and charge.
@@ -71,9 +74,12 @@ def get_sign(charge: int) -> str:
     else:
         return ""
 
-def convert_next_gen_mprest_data(doc) -> Dict[str,Union[pymatgen.core.Structure,Optional[str]]]:
-    """ Converts the `MPDataDoc` object returned by a next-gen MP query to a dictionary
-    
+
+def convert_next_gen_mprest_data(
+    doc,
+) -> Dict[str, Union[pymatgen.core.Structure, Optional[str]]]:
+    """Converts the `MPDataDoc` object returned by a next-gen MP query to a dictionary
+
     Args:
         doc (MPDataDoc): A MPDataDoc object (based on a pydantic model) with fields 'structure' and 'material_id'
     Returns:
@@ -82,7 +88,7 @@ def convert_next_gen_mprest_data(doc) -> Dict[str,Union[pymatgen.core.Structure,
 
     """
     try:
-       return doc.dict(exclude={'fields_not_requested'})
+        return doc.dict(exclude={"fields_not_requested"})
     except:
-        logger.warn(f'Could not convert input:\n {doc}\n to a dictionary.')
+        logger.warn(f"Could not convert input:\n {doc}\n to a dictionary.")
         raise TypeError("Input is not an MPDataDoc object.")

--- a/smact/tests/test_structure.py
+++ b/smact/tests/test_structure.py
@@ -214,6 +214,7 @@ class StructureTest(unittest.TestCase):
         """Test downloading structures from materialsproject.org."""
         # TODO Needs ensuring that the structure query gets the same
         # structure as we have downloaded.
+        # Need to modify the test for both legacy and next-gen queries
         api_key = os.environ.get("MPI_KEY")
 
         for comp, species in self.TEST_SPECIES.items():


### PR DESCRIPTION
This PR closes issue #75 . The `structure_prediction` module has been updated to handle next-gen Materials Project queries alongside legacy queries.

Files changed are:

- `smact/structure_prediction/structure.py`
- `smact/structure_prediction/database.py
- `smact/structure_prediction/utilities.py`

