### PR TITLE
Smact filter

### DIFF
--- a/smact/__init__.py
+++ b/smact/__init__.py
@@ -391,7 +391,7 @@ def _isneutral(oxidations: Tuple[int, ...], stoichs: Tuple[int, ...]):
 
 def neutral_ratios_iter(
     oxidations: List[int],
-    stoichs: Union[bool, List[int]] = False,
+    stoichs: Union[bool, List[List[int]]] = False,
     threshold: Optional[int] = 5,
 ):
     """
@@ -424,7 +424,9 @@ def neutral_ratios_iter(
 
 
 def neutral_ratios(
-    oxidations: List[int], stoichs: Union[bool, List[int]] = False, threshold=5
+    oxidations: List[int],
+    stoichs: Union[bool, List[List[int]]] = False,
+    threshold=5,
 ):
     """
     Get a list of charge-neutral compounds

--- a/smact/screening.py
+++ b/smact/screening.py
@@ -328,6 +328,27 @@ def smact_filter(
         allowed_comps (list): Allowed compositions for that chemical system
         in the form [(elements), (oxidation states), (ratios)] if species_unique=True
         or in the form [(elements), (ratios)] if species_unique=False.
+
+    Example usage:
+        >>> from smact.screening import smact_filter
+        >>> from smact import Element
+        >>> els = (Element('Cs'), Element('Pb'), Element('I'))
+        >>> comps = smact_filter(els, threshold =5 )
+        >>> comps_113 = smact_filter(els, stoichs = [[1],[1],[3]] )
+        >>> for comp in comps:
+        >>>     print(comp)
+        Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, -4, -1), stoichiometries=(5, 1, 1))
+        Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, 2, -1), stoichiometries=(1, 1, 3))
+        Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, 2, -1), stoichiometries=(1, 2, 5))
+        Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, 2, -1), stoichiometries=(2, 1, 4))
+        Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, 2, -1), stoichiometries=(3, 1, 5))
+        Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, 4, -1), stoichiometries=(1, 1, 5))
+
+        >>> for comp in comps_113:
+        >>>     print(comp)
+        Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, 2, -1), stoichiometries=(1, 1, 3))
+
+
     """
 
     compositions = []

--- a/smact/screening.py
+++ b/smact/screening.py
@@ -334,7 +334,6 @@ def smact_filter(
         >>> from smact import Element
         >>> els = (Element('Cs'), Element('Pb'), Element('I'))
         >>> comps = smact_filter(els, threshold =5 )
-        >>> comps_113 = smact_filter(els, stoichs = [[1],[1],[3]] )
         >>> for comp in comps:
         >>>     print(comp)
         Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, -4, -1), stoichiometries=(5, 1, 1))
@@ -344,7 +343,11 @@ def smact_filter(
         Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, 2, -1), stoichiometries=(3, 1, 5))
         Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, 4, -1), stoichiometries=(1, 1, 5))
 
-        >>> for comp in comps_113:
+        Example (using stoichs):
+        >>> from smact.screening import smact_filter
+        >>> from smact import Element
+        >>> comps = smact_filter(els, stoichs = [[1],[1],[3]] )
+        >>> for comp in comps:
         >>>     print(comp)
         Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, 2, -1), stoichiometries=(1, 1, 3))
 

--- a/smact/screening.py
+++ b/smact/screening.py
@@ -343,7 +343,7 @@ def smact_filter(
         Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, 2, -1), stoichiometries=(3, 1, 5))
         Composition(element_symbols=('Cs', 'Pb', 'I'), oxidation_states=(1, 4, -1), stoichiometries=(1, 1, 5))
 
-        Example (using stoichs):
+    Example (using stoichs):
         >>> from smact.screening import smact_filter
         >>> from smact import Element
         >>> comps = smact_filter(els, stoichs = [[1],[1],[3]] )

--- a/smact/screening.py
+++ b/smact/screening.py
@@ -309,8 +309,8 @@ def ml_rep_generator(
 
 def smact_filter(
     els: Union[Tuple[Element], List[Element]],
-    threshold: int = 8,
-    stoichs: Optional[List[int]] = None,
+    threshold: Optional[int] = 8,
+    stoichs: Optional[List[List[int]]] = None,
     species_unique: bool = True,
     oxidation_states_set: str = "default",
 ) -> Union[List[Tuple[str, int, int]], List[Tuple[str, int]]]:

--- a/smact/screening.py
+++ b/smact/screening.py
@@ -310,6 +310,7 @@ def ml_rep_generator(
 def smact_filter(
     els: Union[Tuple[Element], List[Element]],
     threshold: int = 8,
+    stoichs: Optional[List[int]] = None,
     species_unique: bool = True,
     oxidation_states_set: str = "default",
 ) -> Union[List[Tuple[str, int, int]], List[Tuple[str, int]]]:
@@ -320,6 +321,7 @@ def smact_filter(
     Args:
         els (tuple/list): A list of smact.Element objects
         threshold (int): Threshold for stoichiometry limit, default = 8
+        stoichs (list[int]): A selection of valid stoichiometric ratios for each site.
         species_unique (bool): Whether or not to consider elements in different oxidation states as unique in the results.
         oxidation_states_set (string): A string to choose which set of oxidation states should be chosen. Options are 'default', 'icsd', 'pymatgen' and 'wiki' for the default, icsd, pymatgen structure predictor and Wikipedia (https://en.wikipedia.org/wiki/Template:List_of_oxidation_states_of_the_elements) oxidation states respectively.
     Returns:
@@ -357,7 +359,9 @@ def smact_filter(
 
     for ox_states in itertools.product(*ox_combos):
         # Test for charge balance
-        cn_e, cn_r = neutral_ratios(ox_states, threshold=threshold)
+        cn_e, cn_r = neutral_ratios(
+            ox_states, stoichs=stoichs, threshold=threshold
+        )
         # Electronegativity test
         if cn_e:
             electroneg_OK = pauling_test(ox_states, electronegs)

--- a/smact/tests/test_core.py
+++ b/smact/tests/test_core.py
@@ -338,8 +338,9 @@ class TestSequenceFunctions(unittest.TestCase):
 
     def test_smact_filter(self):
         Na, Fe, Cl = (smact.Element(label) for label in ("Na", "Fe", "Cl"))
+        result = smact.screening.smact_filter([Na, Fe, Cl], threshold=2)
         self.assertEqual(
-            smact.screening.smact_filter([Na, Fe, Cl], threshold=2),
+            [(r[0], r[1], r[2]) for r in result],
             [
                 (("Na", "Fe", "Cl"), (1, -1, -1), (2, 1, 1)),
                 (("Na", "Fe", "Cl"), (1, 1, -1), (1, 1, 2)),
@@ -347,6 +348,21 @@ class TestSequenceFunctions(unittest.TestCase):
         )
         self.assertEqual(
             len(smact.screening.smact_filter([Na, Fe, Cl], threshold=8)), 77
+        )
+
+        result = smact.screening.smact_filter(
+            [Na, Fe, Cl], stoichs=[[1], [1], [4]]
+        )
+        self.assertEqual(
+            [(r[0], r[1], r[2]) for r in result],
+            [
+                (("Na", "Fe", "Cl"), (1, 3, -1), (1, 1, 4)),
+            ],
+        )
+        stoichs = [list(range(1, 5)), list(range(1, 5)), list(range(1, 10))]
+        self.assertEqual(
+            len(smact.screening.smact_filter([Na, Fe, Cl], stoichs=stoichs)),
+            45,
         )
 
     # ---------------- Lattice ----------------


### PR DESCRIPTION
# Pull Request Template

## Description

- Corrected typing hints for the stoich argument in `neutral_ratios` and `neutral_ratios_iter`.
- `smact_filter` now takes a stoich argument, so users can supply a list of stoichiometries for each site. This can now allow users to filter for charge-neutral compositions of a particular stoichiometric ratio. 
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Re-ran the test suite to check that the tests aren't broken by the update to `smact_filter`.

The new functionality with the stoichs argument to the `smact_filter` function has had additional tests written to verify that it works.

**Test Configuration**:
* Python version: 3.9.16
* Operating System: WSL2 (Ubuntu)

Tests also pass the following OSs and python versions based of Github Actions:
* Mac
* Ubuntu
* Windows
* Python 3.8
* Python 3.9
* Python 3.10 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
