### PR TITLE
python3.11 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.9","3.10"]
+        python-version: ["3.8","3.9","3.10","3.11"]
         os: [ubuntu-latest,macos-latest,windows-latest]
     
     runs-on: ${{matrix.os}}

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Development Status :: 5 - Production/Stable",
             "Intended Audience :: Science/Research",
             "Operating System :: OS Independent",


### PR DESCRIPTION
# Python 3.11 compatibility 

## Description

* Add Python 3.11 classifier into setup.py
* Add Python 3.11 into Github actions CI


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

* SMACT installed in new python 3.11 environment and pytest was used to check that the installation produced no errors
* Github actions CI showed that SMACT works in Python 3.11

**Test Configuration**:
* Python version: 3.11
* Operating System: WSL2(Ubuntu)


## Reviewers

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
