### PR TITLE
fix: docstring consistency in screening.py

### DIFF
--- a/smact/screening.py
+++ b/smact/screening.py
@@ -43,8 +43,8 @@ def pauling_test(
 
     Returns:
         bool:
-            True if positive ions have lower
-            electronegativity than negative ions
+            True if anions are more electronegative than
+            cations, otherwise False
     """
 
     if repeat_anions and repeat_cations and threshold == 0.0:
@@ -135,8 +135,8 @@ def pauling_test_old(
 
     Returns:
         (bool):
-            True if positive ions have lower
-            electronegativity than negative ions
+            True if anions are more electronegative than
+            cations, otherwise False
 
     """
     if None in paul:
@@ -192,8 +192,8 @@ def eneg_states_test(ox_states: List[int], enegs: List[float]):
             compound
 
     Returns:
-        bool : True if cations have higher electronegativity than
-            anions, otherwise False
+        bool : True if anions are more electronegative than
+               cations, otherwise False
 
     """
     for (ox1, eneg1), (ox2, eneg2) in combinations(
@@ -231,8 +231,8 @@ def eneg_states_test_threshold(
             the Pauling criterion
 
     Returns:
-        bool : True if cations have higher electronegativity than
-            anions, otherwise False
+        bool : True if anions are more electronegative than
+               cations, otherwise False
 
     """
     for (ox1, eneg1), (ox2, eneg2) in combinations(
@@ -259,8 +259,8 @@ def eneg_states_test_alternate(ox_states: List[int], enegs: List[float]):
             compound
 
     Returns:
-        bool : True if cations have higher electronegativity than
-            anions, otherwise False
+        bool : True if anions are more electronegative than
+               cations, otherwise False
 
     """
     min_cation_eneg, max_anion_eneg = 10, 0


### PR DESCRIPTION
# Pull Request Template

## Description

@hspark1212 noticed an inconsistency between the docstrings of `pauling_test` and `eneg_states_test`, the latter of which was incorrect.

These changes make the wording in the docstrings for similar functions more consistent and hopefully less confusing, steering clear of words like "higher" and "lower" when dealing with electronegativity values which are all **positive**, and more positive for more electro**negative** elements. 

## Type of change

Please delete options that are not relevant.

- [ ] docstring change only

## How Has This Been Tested?

No code changes.

## Reviewers

@AntObi - maybe someone can check that the readthedocs page is updated properly after? 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
