### PR TITLE
Add oxidation states option to SMACT validity function

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ conda install -c conda-forge smact
 
 Alternatively, the very latest version can be installed using:
 
-    pip install git+git://github.com/WMD-group/SMACT.git
+    pip install git+https://github.com/WMD-group/SMACT.git
 
 For developer installation SMACT can be installed from a copy of the source
 repository (https://github.com/wmd-group/smact); this will be preferred if using experimental code branches.

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
         test_suite="smact.tests.test",
         install_requires=[
             "scipy",
-            "numpy",
+            "numpy<2",
             "spglib",
             "pymatgen>=2024.2.20",
             "ase",

--- a/smact/screening.py
+++ b/smact/screening.py
@@ -432,8 +432,9 @@ def smact_validity(
     include_alloys: bool = True,
     oxidation_states_set: Union[str, bytes, os.PathLike] = "default",
 ) -> bool:
-    """Check if a composition is valid according to the SMACT rules. Composition is considered valid if it
-        passes the charge neutrality test and the Pauling electronegativity test.
+    """Check if a composition is valid according to the SMACT rules.
+
+    Composition is considered valid if it passes the charge neutrality test and the Pauling electronegativity test.
 
     Args:
         composition (Union[pymatgen.core.Composition, str]): Composition/formula to check. This can be a pymatgen Composition object or a string.

--- a/smact/screening.py
+++ b/smact/screening.py
@@ -439,10 +439,10 @@ def smact_validity(
         use_pauling_test (bool): Whether to use the Pauling electronegativity test
         include_alloys (bool): If True, compositions of metal elements will be considered valid
         oxidation_states_set (Union[str, bytes, os.PathLike]): A string to choose which set of
-        oxidation states should be chosen for charge-balancing. Options are 'default', 'icsd',
-        'pymatgen' and 'wiki' for the default, icsd, pymatgen structure predictor and Wikipedia
-        (https://en.wikipedia.org/wiki/Template:List_of_oxidation_states_of_the_elements) oxidation states respectively.
-        A filepath to an oxidation states text file can also be supplied.
+            oxidation states should be chosen for charge-balancing. Options are 'default', 'icsd',
+            'pymatgen' and 'wiki' for the default, icsd, pymatgen structure predictor and Wikipedia
+            (https://en.wikipedia.org/wiki/Template:List_of_oxidation_states_of_the_elements) oxidation states respectively.
+            A filepath to an oxidation states text file can also be supplied.
 
     Returns:
         bool: True if the composition is valid, False otherwise

--- a/smact/screening.py
+++ b/smact/screening.py
@@ -432,12 +432,13 @@ def smact_validity(
     include_alloys: bool = True,
     oxidation_states_set: Union[str, bytes, os.PathLike] = "default",
 ) -> bool:
-    """Check if a composition is valid according to the SMACT rules.
+    """Check if a composition is valid according to the SMACT rules. Composition is considered valid if it
+        passes the charge neutrality test and the Pauling electronegativity test.
 
     Args:
-        composition (Union[pymatgen.core.Composition, str]): Composition/formula to check
+        composition (Union[pymatgen.core.Composition, str]): Composition/formula to check. This can be a pymatgen Composition object or a string.
         use_pauling_test (bool): Whether to use the Pauling electronegativity test
-        include_alloys (bool): If True, compositions of metal elements will be considered valid
+        include_alloys (bool): If True, compositions which only contain metal elements will be considered valid without further checks.
         oxidation_states_set (Union[str, bytes, os.PathLike]): A string to choose which set of
             oxidation states should be chosen for charge-balancing. Options are 'default', 'icsd',
             'pymatgen' and 'wiki' for the default, icsd, pymatgen structure predictor and Wikipedia

--- a/smact/tests/test_core.py
+++ b/smact/tests/test_core.py
@@ -411,6 +411,25 @@ class TestSequenceFunctions(unittest.TestCase):
         # Test for single element
         self.assertTrue(smact.screening.smact_validity("Al"))
 
+        # Test for MgB2 which is invalid for the default oxi states but valid for the icsd states
+        self.assertFalse(smact.screening.smact_validity("MgB2"))
+        self.assertTrue(
+            smact.screening.smact_validity("MgB2", oxidation_states_set="icsd")
+        )
+        self.assertFalse(
+            smact.screening.smact_validity(
+                "MgB2", oxidation_states_set="pymatgen"
+            )
+        )
+        self.assertTrue(
+            smact.screening.smact_validity("MgB2", oxidation_states_set="wiki")
+        )
+        self.assertFalse(
+            smact.screening.smact_validity(
+                "MgB2", oxidation_states_set=TEST_OX_STATES
+            )
+        )
+
     # ---------------- Lattice ----------------
     def test_Lattice_class(self):
         site_A = smact.lattice.Site([0, 0, 0], -1)


### PR DESCRIPTION
# Pull Request Template

## Description

* This PR adds the option to select the oxidation states to be considered when using the `smact_validity` function.

Fixes #281 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

**Test Configuration**:
* Python version: 3.10
* Operating System: Windows 11


## Reviewers

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced `smact_validity` function to include an `oxidation_states_set` parameter for more flexible charge-balancing options.
  - Introduced new test methods in `DopantPredictionTest` to ensure robustness in dopant prediction features.

- **Updates**
  - Updated installation command in `README.md` to use `https://` instead of `git://`.
  - Included additional data files in setup configuration and updated `numpy` requirement to `<2`.

- **Documentation**
  - Added `"tabulate"` module to imported modules list in documentation configuration.

- **Bug Fixes**
  - Improved `Doper` class with additional parameters and methods for better performance and accuracy.

- **Tests**
  - Expanded test cases in `test_core.py` for `smact_validity` function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->