### PR TITLE
Bump min python version to 3.10 and update metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9","3.10","3.11","3.12"]
+        python-version: ["3.10","3.11","3.12"]
         os: [ubuntu-latest,macos-latest,windows-latest]
     
     runs-on: ${{matrix.os}}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ List of modules
 
 Requirements
 ------------
-The main language is Python 3 and has been tested using Python 3.9+.
+The main language is Python 3 and has been tested using Python 3.10+.
 Basic requirements are Numpy and Scipy.
 The [Atomic Simulation Environment](https://wiki.fysik.dtu.dk/ase) (ASE),  [spglib](http://atztogo.github.io/spglib), and [pymatgen](https://pymatgen.org) are also required for many components.
 

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ __author_email__ = "a.walsh@imperial.ac.uk"
 __copyright__ = (
     "Copyright Daniel W. Davies, Adam J. Jackson, Keith T. Butler (2019)"
 )
-__version__ = "2.7"
+__version__ = "2.7.1"
 __maintainer__ = "Anthony O. Onwuli"
 __maintainer_email__ = "anthony.onwuli16@imperial.ac.uk"
-__date__ = "August 30 2024"
+__date__ = "September 26 2024"
 
 
 import os
@@ -52,9 +52,9 @@ if __name__ == "__main__":
         test_suite="smact.tests.test",
         install_requires=[
             "scipy",
-            "numpy<2",
+            "numpy",
             "spglib",
-            "pymatgen>=2024.2.20,<2024.8.8",
+            "pymatgen>=2024.2.20",
             "ase",
             "pandas",
             "pathos",
@@ -62,7 +62,6 @@ if __name__ == "__main__":
         ],
         classifiers=[
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
@@ -73,5 +72,5 @@ if __name__ == "__main__":
             "Topic :: Scientific/Engineering",
             "Topic :: Scientific/Engineering :: Chemistry",
         ],
-        python_requires=">=3.9",
+        python_requires=">=3.10",
     )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ __author_email__ = "a.walsh@imperial.ac.uk"
 __copyright__ = (
     "Copyright Daniel W. Davies, Adam J. Jackson, Keith T. Butler (2019)"
 )
-__version__ = "2.7.1"
+__version__ = "2.8"
 __maintainer__ = "Anthony O. Onwuli"
 __maintainer_email__ = "anthony.onwuli16@imperial.ac.uk"
 __date__ = "September 26 2024"


### PR DESCRIPTION


## Description

Following suit with pymatgen which in turn follows numpy, scipy and the rest of the NumFOCUS stack, this PR drops Python 3.9 support.

Fixes #316 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

N/A

## Reviewers



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Version updated to 2.8, enhancing overall functionality.
	- Python version requirement updated to 3.10 or higher for improved compatibility.
- **Bug Fixes**
	- Removed upper limit on `numpy` and `pymatgen` dependencies to ensure access to the latest features.
- **Chores**
	- Updated CI workflow to test against Python versions 3.10, 3.11, and 3.12 only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->