### PR TITLE
Try MP_API_KEY in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           pip install -e ".[crystal_space,dev]"
           pip install pytest-cov
       - name: Run tests and collect coverage
+        env:
+          MP_API_KEY: ${{ secrets.MP_API_KEY }}
         run: python -m pytest --cov=smact --cov-report=xml -v
       - name: Upload coverage reports to CodeCov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
# Test MP API KEY in the workflow

## Description

To ensure that any future updates to SMACT don't break workflows dependent on the Materials Project API, I have added an API Key as a secret

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**Test Configuration**:

- Python version: 3.10
- Operating System: macOS

## Reviewers

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
