### PR TITLE
Include crystal space utils in package build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SMACT"
-version = "3.0.1"
+version = "3.0.2"
 description = "Semiconducting Materials by Analogy and Chemical Theory"
 readme = "README.md"
 authors = [
@@ -121,9 +121,7 @@ strict = [
     "dash==2.18.2",
 ]
 
-[tool.semantic_release]
-version_variable = "setup.py:__version__"
-version_source = "tag"
+
 
 [tool.ruff]
 target-version = "py310"

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 __author__ = "The SMACT Developers"
 __author_email__ = "a.walsh@imperial.ac.uk"
 __copyright__ = "Copyright Daniel W. Davies, Adam J. Jackson, Keith T. Butler (2019)"
-__version__ = "3.0"
+__version__ = "3.0.2"
 __maintainer__ = "Anthony O. Onwuli"
 __maintainer_email__ = "anthony.onwuli16@imperial.ac.uk"
-__date__ = "December 2 2024"
+__date__ = "January 13 2025"
 
 
 import os
@@ -40,7 +40,7 @@ if __name__ == "__main__":
             "smact.tests",
             "smact.structure_prediction",
             "smact.dopant_prediction",
-            "smact.utils",
+            "smact.utils.crystal_space",
         ],
         package_data={
             "smact": [


### PR DESCRIPTION
# Ensure smact.utils.crystal_space is accessible from a pip installation

## Description

A minor oversight in the `setup.py` file has meant that `smact.utils.crystal_space` is not included in distributions of SMACT. This PR corrects this issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have built `SMACT` locally with the changes and have confirmed that `crystal_space` is included in the source tarbell

**Test Configuration**:

- Python version: 3.10
- Operating System: macOS

## Reviewers

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
  - Bumped project version from 3.0.1 to 3.0.2
  - Updated release date to January 13 2025

- **Package Structure**
  - Refined package organisation by updating utility package references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->