### PR TITLE
Fix the MP URL to ensure tests run

### DIFF
--- a/smact/tests/test_structure.py
+++ b/smact/tests/test_structure.py
@@ -32,7 +32,7 @@ from smact.structure_prediction.mutation import CationMutator
 from smact.structure_prediction.prediction import StructurePredictor
 from smact.structure_prediction.structure import SmactStructure
 
-MP_URL = "https://materialsproject.org"
+MP_URL = "https://api.materialsproject.org"
 MP_API_AVAILABLE = bool(find_spec("mp_api"))
 
 try:

--- a/smact/tests/test_utils.py
+++ b/smact/tests/test_utils.py
@@ -17,7 +17,7 @@ from smact.utils.composition import comp_maker, formula_maker, parse_formula
 from smact.utils.crystal_space import generate_composition_with_smact
 from smact.utils.oxidation import ICSD24OxStatesFilter
 
-MP_URL = "https://materialsproject.org"
+MP_URL = "https://api.materialsproject.org"
 MP_API_AVAILABLE = bool(find_spec("mp_api"))
 
 try:


### PR DESCRIPTION
# Fix the MP URL to ensure tests run

## Description

* This PR corrects the URL used for the Materials Project in the test suite as currently these tests are automatically skipped.



## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Ran tests locally with `mp-api` installed and no tests were skipped
- Ran tests after uninstalling `mp-api` and the two affected tests were skipped as expected

**Test Configuration**:

- Python version: 3.10
- Operating System: macOS

## Reviewers


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Materials Project API endpoint URLs in test files from the main website to the dedicated API domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->