### PR TITLE
Remove redundant pre-commit qa in Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,7 @@ on:
       - master
 
 jobs:
-  qa:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pre-commit/action@v3.0.1
-
   test:
-    needs: qa
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Remove redundant pre-commit qa in Actions

## Description

* The QA step in the CI is redundant with pre-commit.ci
* This PR removes this part of the workflow


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified that the CI still works with this removed.

**Test Configuration**:

N/A

## Reviewers

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
