### PR TITLE
WIP: Support validity for mixed valence compounds

### DIFF
--- a/smact/screening.py
+++ b/smact/screening.py
@@ -21,6 +21,7 @@ from smact.metallicity import metallicity_score
 if TYPE_CHECKING:
     import pymatgen
 
+MIXED_VALENCE_ELEMENTS = ["Fe", "Mn", "Co", "Cu", "Ni", "V", "Ti", "Cr", "Nb", "Mo", "W", "Re", "Ru", "Os", "Pd", "Ag", "Au", "Sn", "Sb", "Bi"]
 
 def pauling_test(
     oxidation_states: list[int],
@@ -432,6 +433,7 @@ def smact_validity(
     include_zero: bool = False,
     consensus: int = 3,
     commonality: str = "medium",
+    mixed_valence: bool = False,
 ) -> bool:
     """
     Check if a composition is valid according to SMACT rules:
@@ -450,6 +452,7 @@ def smact_validity(
         include_zero (bool): Include oxidation state of zero in the filtered list. Default is False.
         consensus (int): Minimum number of occurrences in literature for an ion to be considered valid. Default is 3.
         commonality (str): Excludes species below a certain proportion of appearances in literature with respect to the total number of reports of a given element (after the consensus threshold has been applied). "low" includes all species, "medium" excludes rare species below 10% occurrence, and "high" excludes non-majority species below 50% occurrence. "main" selects the species with the highest occurrence for a given element. Users may also specify their own threshold (float or int). Default is "medium".
+        mixed_valence (bool): If True, allow mixed valence elements to be treated as separate species. Default is False.
 
     Returns:
         bool: True if the composition is valid, False otherwise.
@@ -527,6 +530,37 @@ def smact_validity(
         raise ValueError(f"{oxidation_states_set} is not valid. Provide a known set or a valid file path.")
 
     # Check all possible oxidation state combinations
+    ox_valid = _is_valid_oxi_state(ox_combos, stoichs, threshold, electronegs, use_pauling_test)
+
+    if ox_valid:
+        return True
+    elif mixed_valence and any([el in MIXED_VALENCE_ELEMENTS for el in elem_symbols]):
+        # treat any potential mixed valence elements as separate species
+        ox_combos, stoichs, electronegs = _expand_mixed_valence_comp(ox_combos, stoichs, electronegs, elem_symbols)
+        return _is_valid_oxi_state(ox_combos, stoichs, threshold, electronegs, use_pauling_test)
+
+    return False
+
+
+def _expand_mixed_valence_comp(ox_combos, stoichs, electronegs, elem_symbols):
+    """Utility function to expand mixed valence elements in the composition."""
+    new_ox_combos = []
+    new_stoichs = []
+    new_electronegs = []
+    for el, ox, count, electrnoeg in zip(elem_symbols, ox_combos, stoichs, electronegs):
+        if el in MIXED_VALENCE_ELEMENTS:
+            new_ox_combos.extend([ox] * count[0])
+            new_electronegs.extend([electrnoeg] * count[0])
+            new_stoichs.extend([(1, )] * count[0])
+        else:
+            new_ox_combos.append(ox)
+            new_electronegs.append(electrnoeg)
+            new_stoichs.append(count)
+    return new_ox_combos, new_stoichs, new_electronegs
+
+
+def _is_valid_oxi_state(ox_combos, stoichs, threshold, electronegs, use_pauling_test=True):
+    """Utility function to check if there is a valid oxidation state solution."""
     for ox_states in itertools.product(*ox_combos):
         cn_e, cn_r = neutral_ratios(ox_states, stoichs=stoichs, threshold=threshold)
 

--- a/smact/tests/test_core.py
+++ b/smact/tests/test_core.py
@@ -484,6 +484,17 @@ class TestSequenceFunctions(unittest.TestCase):
         test_ox_states = join(files_dir, "test_oxidation_states.txt")
         self.assertTrue(smact.screening.smact_validity("NaCl", oxidation_states_set=test_ox_states))
 
+    def test_smact_validity_mixed_valence(self):
+        """Test mixed valence handling in smact_validity."""
+        self.assertFalse(
+            smact.screening.smact_validity("Fe3O4"),
+            f"Failed with mixed_valence=False: Fe3O4",
+        )
+        self.assertTrue(
+            smact.screening.smact_validity("Fe3O4", mixed_valence=True),
+            f"Failed with mixed_valence=True: Fe3O4",
+        )
+
     def test_smact_validity_error_handling(self):
         """
         Test error handling in smact_validity


### PR DESCRIPTION
## Description

**This PR is WIP while we finalise the list of supported mixed valence elements**.

Added support for mixed valence compounds in the `smact_validity` function. The default behaviour of the function has not changed. For example:

```python
from smact.screening import smact_validity

smact_validity("Fe3O4")
# returns False

smact_validity("Fe3O4", mixed_valence=True)
# returns True
```

The algorithm is as follows:
1. If a composition passes the regular oxidation state checking, the function proceeds as normal.
2. If a composition cannot be made to charge balance we first check if it contains any elements that are known to result in mixed valence compositions. The choice of these elements was based on screening of the ICSD.
3. If so, we "expand" the composition to treat potential mixed valence element as separate species. For example, Fe3O4 would be treated as FeFeFeO4.
4. We then perform the oxidation state checking again using the expanded composition.

The algorithm will fail if the reduced formula does not support mixed valence elements due to limited multiplicity. For example, Cs2SbCl6, which contains Sb3+ and Sb5+. To overcome this, a future fix could be to add another option to repeat the composition up to a fixed number (i.e., Cs4SbSbCl12).
​	
This PR addresses #196 and #418.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Added a `test_smact_validity_mixed_valence` in `tests_core.py`.

## Reviewers

@Panyalak @dandavies99 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
