### PR TITLE
Revert "WIP: Support validity for mixed valence compounds"

### DIFF
--- a/smact/tests/test_core.py
+++ b/smact/tests/test_core.py
@@ -484,17 +484,6 @@ class TestSequenceFunctions(unittest.TestCase):
         test_ox_states = join(files_dir, "test_oxidation_states.txt")
         self.assertTrue(smact.screening.smact_validity("NaCl", oxidation_states_set=test_ox_states))
 
-    def test_smact_validity_mixed_valence(self):
-        """Test mixed valence handling in smact_validity."""
-        self.assertFalse(
-            smact.screening.smact_validity("Fe3O4"),
-            "Failed with mixed_valence=False: Fe3O4",
-        )
-        self.assertTrue(
-            smact.screening.smact_validity("Fe3O4", mixed_valence=True),
-            "Failed with mixed_valence=True: Fe3O4",
-        )
-
     def test_smact_validity_error_handling(self):
         """
         Test error handling in smact_validity


### PR DESCRIPTION
Reverts WMD-group/SMACT#441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified chemical validity checking by removing mixed-valence handling and streamlining the validation process.

* **Tests**
  * Updated tests to reflect changes to validity checking logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->