### PR TITLE
Change Dependabot update schedule to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,13 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: daily
+    open-pull-requests-limit: 10
     target-branch: develop
 
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: daily
+    open-pull-requests-limit: 10
     target-branch: develop


### PR DESCRIPTION
Changed the update schedule for GitHub Actions and pip dependencies from monthly to daily, and set the open pull requests limit to 10.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Dependabot will now check for dependency updates daily rather than monthly.
  * Implemented a limit of 10 concurrent open dependency update pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->