### PR TITLE
Fix TypeError crash for noble gases with explicit oxidation state sets

### DIFF
--- a/smact/screening.py
+++ b/smact/screening.py
@@ -591,6 +591,11 @@ def smact_validity(
     else:
         raise ValueError(f"{oxidation_states_set} is not valid. Provide a known set or a valid file path.")
 
+    # Guard: if any element has no oxidation states in the chosen set (e.g. noble
+    # gases in most databases), the composition cannot be charge-balanced.
+    if any(ox is None or len(ox) == 0 for ox in ox_combos):
+        return False
+
     # Check all possible oxidation state combinations
     ox_valid = _is_valid_oxi_state(ox_combos, stoichs, threshold, electronegs, use_pauling_test)
 

--- a/smact/screening.py
+++ b/smact/screening.py
@@ -460,12 +460,20 @@ def smact_filter(
                 stacklevel=2,
             )
     elif os.path.exists(oxidation_states_set):
-        ox_combos = (oxi_custom(e.symbol, oxidation_states_set) for e in els)
+        ox_combos = [oxi_custom(e.symbol, oxidation_states_set) for e in els]
     else:
         raise (
             Exception(
                 f'{oxidation_states_set} is not valid. Enter either "smact14", "icsd", "pymatgen","wiki" or a filepath to a textfile of oxidation states.'
             )
+        )
+
+    # Guard: raise early if any element has no oxidation states in the chosen set
+    missing = [e.symbol for e, ox in zip(els, ox_combos, strict=False) if ox is None or len(ox) == 0]
+    if missing:
+        raise ValueError(
+            f"No oxidation states found for {missing} in oxidation_states_set='{oxidation_states_set}'. "
+            "Cannot enumerate charge-neutral compositions."
         )
 
     compositions = []
@@ -578,7 +586,7 @@ def smact_validity(
         ox_combos = [el.oxidation_states_icsd16 for el in smact_elems]
     elif oxidation_states_set == "pymatgen_sp":
         ox_combos = [el.oxidation_states_sp for el in smact_elems]
-    elif oxidation_states_set == "icsd24" or oxidation_states_set is None:
+    elif oxidation_states_set == "icsd24":
         ox_combos = [el.oxidation_states_icsd24 for el in smact_elems]
     elif os.path.exists(oxidation_states_set):
         ox_combos = [oxi_custom(el.symbol, oxidation_states_set) for el in smact_elems]

--- a/smact/tests/test_core.py
+++ b/smact/tests/test_core.py
@@ -442,6 +442,20 @@ class TestSequenceFunctions(unittest.TestCase):
         finally:
             smact.screening.pauling_test = original_pauling_test
 
+    def test_smact_validity_noble_gases(self):
+        """
+        Test that noble gases with no oxidation states return False cleanly
+        (no TypeError) regardless of which oxidation_states_set is used.
+        """
+        for ox_set in ["smact14", "icsd16", "icsd24", "pymatgen_sp"]:
+            self.assertFalse(
+                smact.screening.smact_validity("NeF2", oxidation_states_set=ox_set),
+                f"NeF2 should be False with oxidation_states_set={ox_set}",
+            )
+        # Xe and Kr have known oxidation states and should still pass
+        self.assertTrue(smact.screening.smact_validity("XeF2"))
+        self.assertTrue(smact.screening.smact_validity("KrF2"))
+
     def test_smact_validity_special_cases(self):
         """
         Test special cases in smact_validity:

--- a/smact/tests/test_core.py
+++ b/smact/tests/test_core.py
@@ -455,6 +455,9 @@ class TestSequenceFunctions(unittest.TestCase):
         # Xe and Kr have known oxidation states and should still pass
         self.assertTrue(smact.screening.smact_validity("XeF2"))
         self.assertTrue(smact.screening.smact_validity("KrF2"))
+        # Also verify the explicit oxidation_states_set path (the reported bug case)
+        self.assertTrue(smact.screening.smact_validity("XeF2", oxidation_states_set="icsd24"))
+        self.assertTrue(smact.screening.smact_validity("KrF2", oxidation_states_set="icsd24"))
 
     def test_smact_validity_special_cases(self):
         """


### PR DESCRIPTION
## Summary

- `smact_validity` with an explicit `oxidation_states_set` (e.g. `'smact14'`, `'icsd16'`) raised an unhandled `TypeError` for compositions containing noble gases (He, Ne, Ar, Rn) because their `None` oxidation states were passed directly to `itertools.product`
- The `oxidation_states_set=None` default path already had an element-level guard; this PR adds an equivalent single guard after all explicit-set branches
- Noble gas compounds with known oxidation states (Kr, Xe) continue to work correctly

## Test plan

- [ ] `smact_validity('NeF2', oxidation_states_set='smact14')` returns `False` without crashing
- [ ] `smact_validity('XeF2', oxidation_states_set='icsd24')` still returns `True`
- [ ] All 30 existing tests pass

Fixes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation to prevent errors when processing compounds with undefined or invalid oxidation states. The system now returns early when oxidation-state data is missing or incomplete, avoiding downstream processing failures.

* **Tests**
  * Added comprehensive test coverage for noble gas validity assessment across multiple oxidation state datasets to ensure correct handling of elements with undefined oxidation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->