### PR TITLE
Pre-release cleanup for v4.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ The steps for a new piece of work can be summarised as follows:
 git remote add upstream https://github.com/WMD-group/SMACT.git
 ```
 
-Fetch the latest changes from the master branch to keep it up to date (make sure you are on the master branch ).
+Fetch the latest changes from the master branch to keep it up to date (make sure you are on the master branch).
 
 ```bash
 git checkout master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.01361/status.svg)](https://doi.org/10.21105/joss.01361)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.595853.svg)](https://doi.org/10.5281/zenodo.595853)
-[![Documentation Status](https://readthedocs.org/projects/smact/badge/?version=latest)](http://smact.readthedocs.org/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/smact/badge/?version=latest)](https://smact.readthedocs.org/en/latest/?badge=latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![python version](https://img.shields.io/pypi/pyversions/smact)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 Semiconducting Materials from Analogy and Chemical Theory
 =========================================================
 
-View the code on Github `here <http://github.com/wmd-group/smact>`_.
+View the code on Github `here <https://github.com/wmd-group/smact>`_.
 
 Introduction
 ============
@@ -24,7 +24,7 @@ Features of :mod:`smact` include:
 
 - Chemical elements with associated properties
 - Filters for oxidation states and charge balancing
-- Structure predcition from chemical composition
+- Structure prediction from chemical composition
 - Composition probability prediction
 - Property prediction from composition using pre-trained ROOST models
 

--- a/docs/smact.dopant_prediction.doper.rst
+++ b/docs/smact.dopant_prediction.doper.rst
@@ -1,5 +1,5 @@
 smact.dopant_prediction.doper module
-=============================
+====================================
 
 A class to create possible n-type and p-type dopants according to
 their accessible oxidation states.

--- a/docs/smact.dopant_prediction.rst
+++ b/docs/smact.dopant_prediction.rst
@@ -1,5 +1,5 @@
-Dopant Prediction Module
-===========================
+smact.dopant_prediction module
+==============================
 
 The dopant prediction module facilitates high-throughput prediction of p-type and n-type dopants in multi-component solids. The search and ranking process is based on electronic filters (e.g. accessible oxidation states) and chemical filters (e.g. difference in ionic radius).
 

--- a/docs/smact.metallicity.rst
+++ b/docs/smact.metallicity.rst
@@ -1,5 +1,5 @@
 smact.metallicity module
-====================
+========================
 
 .. automodule:: smact.metallicity
     :members:

--- a/docs/smact.property_prediction.base_predictor.rst
+++ b/docs/smact.property_prediction.base_predictor.rst
@@ -1,5 +1,5 @@
 smact.property_prediction.base_predictor module
-================================================
+===============================================
 
 Abstract base class for property predictors and the
 :class:`~smact.property_prediction.base_predictor.PredictionResult`

--- a/docs/smact.property_prediction.convenience.rst
+++ b/docs/smact.property_prediction.convenience.rst
@@ -1,5 +1,5 @@
 smact.property_prediction.convenience module
-=============================================
+============================================
 
 Convenience wrapper functions for common property predictions,
 allowing users to predict properties with minimal setup.

--- a/docs/smact.property_prediction.io.rst
+++ b/docs/smact.property_prediction.io.rst
@@ -1,5 +1,5 @@
 smact.property_prediction.io module
-====================================
+===================================
 
 Model I/O utilities for loading, saving, and caching pretrained models.
 

--- a/docs/smact.property_prediction.registry.rst
+++ b/docs/smact.property_prediction.registry.rst
@@ -1,5 +1,5 @@
 smact.property_prediction.registry module
-==========================================
+=========================================
 
 Model registry for discovering and resolving pretrained models,
 including functions to query available properties, fidelities, and

--- a/docs/smact.property_prediction.roost.rst
+++ b/docs/smact.property_prediction.roost.rst
@@ -1,5 +1,5 @@
 smact.property_prediction.roost module
-=======================================
+======================================
 
 ROOST (Representation Learning from Stoichiometry) predictor
 implementation for composition-only property prediction.

--- a/docs/smact.property_prediction.rst
+++ b/docs/smact.property_prediction.rst
@@ -1,5 +1,5 @@
-Property Prediction Module
-===========================
+smact.property_prediction module
+================================
 
 The property prediction module enables prediction of material properties
 directly from chemical composition, without requiring crystal structure

--- a/docs/smact.structure_prediction.database.rst
+++ b/docs/smact.structure_prediction.database.rst
@@ -1,5 +1,5 @@
-Structure Database Module
-=========================
+smact.structure_prediction.database module
+==========================================
 
 Implements :class:`~.StructureDB`: a minimalist SQLite
 database for storing :class:`~.SmactStructure`-compatible

--- a/docs/smact.structure_prediction.mutation.rst
+++ b/docs/smact.structure_prediction.mutation.rst
@@ -1,5 +1,5 @@
-Mutation Module
-===============
+smact.structure_prediction.mutation module
+==========================================
 
 Contains tools for determining substitution probability
 of different species and for mutating instances of

--- a/docs/smact.structure_prediction.prediction.rst
+++ b/docs/smact.structure_prediction.prediction.rst
@@ -1,5 +1,5 @@
-Prediction Module
-=================
+smact.structure_prediction.prediction module
+============================================
 
 Prediction algorithm implementation. Wraps the structure prediction
 pipeline.

--- a/docs/smact.structure_prediction.probability_models.rst
+++ b/docs/smact.structure_prediction.probability_models.rst
@@ -1,5 +1,5 @@
-Substitution Probability Models
-===============================
+smact.structure_prediction.probability_models module
+====================================================
 
 Minimal API for developing substitution likelihood probability models
 for species mutation.

--- a/docs/smact.structure_prediction.rst
+++ b/docs/smact.structure_prediction.rst
@@ -1,5 +1,5 @@
-Structure Prediction Module
-===========================
+smact.structure_prediction module
+=================================
 
 The structure prediction module implements a minimalist
 framework for high-throughput prediction of new compounds

--- a/docs/smact.structure_prediction.structure.rst
+++ b/docs/smact.structure_prediction.structure.rst
@@ -1,5 +1,5 @@
-Structure Module
-================
+smact.structure_prediction.structure module
+===========================================
 
 Contains a minimalist :class:`~.SmactStructure` class
 for simple crystal structure and chemical composition

--- a/docs/smact.structure_prediction.utilities.rst
+++ b/docs/smact.structure_prediction.utilities.rst
@@ -1,5 +1,5 @@
-Structure Prediction Utilities Module
-=====================================
+smact.structure_prediction.utilities module
+===========================================
 
 Miscellaneous utilities for data manipulation.
 

--- a/docs/smact.utils.composition.rst
+++ b/docs/smact.utils.composition.rst
@@ -1,5 +1,5 @@
-SMACT Utilities Composition Module
-=====================================
+smact.utils.composition module
+==============================
 
 Miscellaneous utilities for composition handling
 

--- a/docs/smact.utils.crystal_space.download_compounds_with_mp_api.rst
+++ b/docs/smact.utils.crystal_space.download_compounds_with_mp_api.rst
@@ -1,5 +1,5 @@
-Crystal Space Materials Project Data Retrieval Module
-===========================
+smact.utils.crystal_space.download_compounds_with_mp_api module
+===============================================================
 
 
 .. automodule:: smact.utils.crystal_space.download_compounds_with_mp_api

--- a/docs/smact.utils.crystal_space.generate_composition_with_smact.rst
+++ b/docs/smact.utils.crystal_space.generate_composition_with_smact.rst
@@ -1,5 +1,5 @@
-Crystal Space SMACT Generation Module
-===========================
+smact.utils.crystal_space.generate_composition_with_smact module
+================================================================
 
 .. automodule:: smact.utils.crystal_space.generate_composition_with_smact
     :members:

--- a/docs/smact.utils.crystal_space.plot_embedding.rst
+++ b/docs/smact.utils.crystal_space.plot_embedding.rst
@@ -1,5 +1,5 @@
-Crystal Space Embedding Module
-===========================
+smact.utils.crystal_space.plot_embedding module
+===============================================
 
 
 .. automodule:: smact.utils.crystal_space.plot_embedding

--- a/docs/smact.utils.crystal_space.rst
+++ b/docs/smact.utils.crystal_space.rst
@@ -1,5 +1,5 @@
-SMACT Utilities Crystal Space Module
-===========================
+smact.utils.crystal_space module
+================================
 
 Utility functions associated with our `Faraday Discussions publication 'Mapping Inorganic Crystal Space' <https://doi.org/10.1039/D4FD00063C>`_  using SMACT
 

--- a/docs/smact.utils.oxidation.rst
+++ b/docs/smact.utils.oxidation.rst
@@ -1,5 +1,5 @@
-SMACT Utilities Oxidation Module
-=====================================
+smact.utils.oxidation module
+============================
 
 Miscellaneous utilities for creating SMACT compatible oxidation states list
 

--- a/docs/smact.utils.rst
+++ b/docs/smact.utils.rst
@@ -1,5 +1,5 @@
-SMACT Utilities module
-===========================
+smact.utils module
+==================
 
 The utilities module provides some utility functions to support the core functionalities of SMACT
 

--- a/smact/lattice_parameters.py
+++ b/smact/lattice_parameters.py
@@ -90,7 +90,7 @@ def wurtzite(
     gamma = 120
     #
     # Scenario A: A atoms are touching
-    #   i.e. height is that of two tetrahegons with side length a
+    #   i.e. height is that of two tetrahedra with side length a
     #    = 2 * sqrt(2/3) * a
     if shannon_radius[0] > _TETRAHEDRAL_HALF_ANGLE_SIN * (shannon_radius[0] + shannon_radius[1]):
         a = 2 * shannon_radius[0]

--- a/smact/tests/test_utils.py
+++ b/smact/tests/test_utils.py
@@ -431,7 +431,6 @@ def test_get_species_list(ox_filter):
 def test_oxidation_states_filter_species_occurrences(ox_filter):
     species_occurrences_df = ox_filter.get_species_occurrences_df(consensus=1)
     assert isinstance(species_occurrences_df, pd.DataFrame)
-    assert isinstance(species_occurrences_df, pd.DataFrame)
     assert species_occurrences_df.columns.tolist() == [
         "element",
         "species",
@@ -474,7 +473,6 @@ def test_commonality_type_error(ox_filter):
 def test_get_species_occurrences_unsorted(ox_filter):
     occurrences = ox_filter.get_species_occurrences_df(sort_by_occurrences=False)
     assert isinstance(occurrences, pd.DataFrame)
-    assert isinstance(occurrences, pd.DataFrame)
     assert len(occurrences) > 0
 
 
@@ -486,7 +484,6 @@ def test_filter_numeric_commonality(ox_filter):
 
 def test_get_species_occurrences_include_zero(ox_filter):
     occurrences = ox_filter.get_species_occurrences_df(include_zero=True)
-    assert isinstance(occurrences, pd.DataFrame)
     assert isinstance(occurrences, pd.DataFrame)
     assert len(occurrences) > 0
 


### PR DESCRIPTION
## Summary
- Fix typos: "predcition" → "prediction" in `docs/index.rst`, "tetrahegons" → "tetrahedra" in `smact/lattice_parameters.py`
- Use HTTPS for readthedocs and GitHub URLs in `README.md` and `docs/index.rst`
- Standardise all 23 RST module doc titles to consistent `smact.module_name module` convention (was a mix of Title Case, SMACT prefix, and lowercase)
- Fix 15 RST underline length mismatches
- Remove 3 duplicate `assert isinstance()` lines in `smact/tests/test_utils.py`
- Fix extra space before `)` in `CONTRIBUTING.md`

## Test plan
- [x] `pre-commit run --all-files` passes (all hooks except pre-existing pyright optional dep errors)
- [x] `pytest` — 282 tests pass
- [ ] CI passes on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardised module documentation titles and formatting across all API reference pages.
  * Updated documentation links from HTTP to HTTPS.
  * Corrected spelling errors in documentation and code comments.

* **Tests**
  * Removed redundant assertions from utility tests.

* **Style**
  * Fixed spacing and formatting issues in contributing guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->