### PR TITLE
test: read the MP API key from the same sources the skip guard accepts

### DIFF
--- a/smact/tests/test_utils.py
+++ b/smact/tests/test_utils.py
@@ -292,7 +292,7 @@ def test_download_compounds_with_mp_api():
     save_mp_dir = "data/binary/mp_data"
     if MP_API_AVAILABLE:
         download_compounds_with_mp_api.download_mp_data(
-            mp_api_key=os.environ.get("MP_API_KEY"),
+            mp_api_key=os.environ.get("MP_API_KEY") or SETTINGS.get("PMG_MAPI_KEY"),
             num_elements=2,
             max_stoich=1,
             save_dir=save_mp_dir,


### PR DESCRIPTION
`test_download_compounds_with_mp_api` skips unless `MP_API_KEY` is in the environment **or** `PMG_MAPI_KEY` is in pymatgen's `SETTINGS` (`smact/tests/test_utils.py:281-288`), but the call site passed only `os.environ.get("MP_API_KEY")`.

So anyone who configured their Materials Project key the usual pymatgen way — `PMG_MAPI_KEY` in `~/.config/.pmgrc.yaml` — is not skipped, and then fails:

```
ValueError: Please set your MP_API_KEY in the environment variable.
smact/utils/crystal_space/download_compounds_with_mp_api.py:55
```

CI never sees this because it sets `MP_API_KEY` explicitly from a secret, so the test passes there and skips on Windows. It only bites local runs, which is where a new contributor or a reviewer meets it.

One-line fix: fall back to `SETTINGS` at the call site so both key sources the guard accepts actually work.

## Verification

Locally, with `PMG_MAPI_KEY` set in `~/.config/.pmgrc.yaml` and no `MP_API_KEY`:

- before: `1 failed, 313 passed`
- after: `352 passed` from `uv run pytest`, matching CI's ubuntu-3.12 count exactly, with nothing skipped

Environment synced with `uv sync --extra optional --extra property_prediction --dev`, as CI does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test configuration so compound data downloads can use the configured Materials Project API key when the environment variable is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->