### PR TITLE
security: run CI on pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,13 @@
 name: SMACT CI
 
+# Triggered by `pull_request`, not `pull_request_target`. This workflow builds and runs
+# the code from the pull request, including installing its dependencies and executing its
+# pre-commit hooks, so it must not run with access to the base repository's secrets. Under
+# `pull_request` a fork's job gets no secrets and a read-only token, and the workflow
+# definition comes from the pull request, so changes to this file are validated before
+# they are merged. See also packaging.yml, which is triggered the same way.
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - master
@@ -16,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@v7
@@ -45,8 +49,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install uv and set up Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v7
@@ -65,7 +67,11 @@ jobs:
         env:
           MP_API_KEY: ${{ secrets.MP_API_KEY }}
         run: uv run pytest --cov=smact --cov-report=xml -v
+      # CODECOV_TOKEN is not available to pull requests from forks, and the step below
+      # fails the job when an upload errors. Skip it there rather than showing a
+      # contributor a red build they cannot fix.
       - name: Upload coverage reports to CodeCov
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Closes the one open CodeQL alert: `actions/untrusted-checkout/high` at `.github/workflows/ci.yml:46`.

## The problem

`ci.yml` triggered on `pull_request_target`, which runs in the context of the **base** repository with its secrets, and then explicitly checked out the fork's commit:

```yaml
on:
  pull_request_target:
...
      - name: Checkout repository
        uses: actions/checkout@v6
        with:
          ref: ${{ github.event.pull_request.head.sha }}
```

and ran `uv sync --extra optional --extra property_prediction --dev`, `uv run pre-commit run --all-files` and `uv run pytest` against it. All three execute code the pull request controls — build hooks, pre-commit hook definitions, test code — in a job holding `secrets.MP_API_KEY` and `secrets.CODECOV_TOKEN`.

The workflow-level `permissions: contents: read` constrains the `GITHUB_TOKEN`, which is good, but does nothing about the secrets. Any pull request from a fork could read them.

## The fix

`pull_request`. Fork jobs get no secrets and a read-only token, so there is nothing to exfiltrate. It also means the workflow definition comes from the pull request, so a change to this file is validated before merge rather than after — this PR's own first run exercises the new configuration, which `pull_request_target` could not do.

`packaging.yml` already works this way and carries a comment explaining why; ci.yml just predates it. Added a matching comment.

The explicit `ref:` goes too. Under `pull_request` the default checkout is the merge commit, which is the more useful thing to test, and the `workflow_call` path from `publish-to-pypi.yml` has no `pull_request` payload so it resolved to the default already.

## One behaviour change worth knowing about

Fork pull requests no longer receive secrets, which affects two steps:

- `test_download_compounds_with_mp_api` skips without `MP_API_KEY`, which is what its `skipif` is for. It still runs for branch PRs and for `push` to master. #647 made the two key sources it accepts consistent.
- The Codecov upload sets `fail_ci_if_error: true`, so a missing `CODECOV_TOKEN` would turn into a red build for an external contributor. Guarded the step to same-repo events instead.

## Verification

`pre-commit run --files .github/workflows/ci.yml` passes; the YAML parses with the expected triggers (`pull_request`, `push`, `workflow_call`), `permissions: contents: read`, and neither checkout step carrying a `with:` block.