### PR TITLE
Update the spglib documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ graph TD
 ## Requirements
 
 The main language is Python 3 and has been tested using Python 3.11 - 3.13.
-Core dependencies include NumPy, SciPy, pandas, [pymatgen](https://pymatgen.org), [ASE](https://wiki.fysik.dtu.dk/ase), and [spglib](http://atztogo.github.io/spglib). A full list is in [`pyproject.toml`](pyproject.toml).
+Core dependencies include NumPy, SciPy, pandas, [pymatgen](https://pymatgen.org), [ASE](https://wiki.fysik.dtu.dk/ase), and [spglib](https://spglib.readthedocs.io). A full list is in [`pyproject.toml`](pyproject.toml).
 
 ## Installation
 


### PR DESCRIPTION
The README links spglib as `http://atztogo.github.io/spglib`, which 404s. spglib moved out of the personal namespace and its documentation is now at `https://spglib.readthedocs.io`.

Checked that the new URL returns 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the spglib documentation link in the Requirements section to point to its current HTTPS documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->