### PR TITLE
fix: convert dict-serialised structure in parse_mprest for newer mp-api

### DIFF
--- a/smact/structure_prediction/database.py
+++ b/smact/structure_prediction/database.py
@@ -18,7 +18,7 @@ except ImportError:  # pragma: no cover
 import os
 import re
 import sqlite3
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from pymatgen.core import SETTINGS
 from pymatgen.core import Structure as pmg_Structure
@@ -125,7 +125,7 @@ class StructureDB:
     def add_mp_icsd(
         self,
         table: str,
-        mp_data: list[dict[str, pmg_Structure | str]] | None = None,
+        mp_data: list[dict[str, pmg_Structure | dict[str, Any] | str]] | None = None,
         mp_api_key: str | None = None,
     ) -> int:
         """
@@ -319,7 +319,7 @@ class StructureDB:
 
 
 def parse_mprest(
-    data: dict[str, pmg_Structure | str],
+    data: dict[str, pmg_Structure | dict[str, Any] | str],
     determine_oxi: str = "BV",
 ) -> SmactStructure | None:
     """
@@ -327,7 +327,8 @@ def parse_mprest(
 
     Args:
         data: A dictionary containing the keys 'structure' and
-            'material_id', with the associated values.
+            'material_id'. 'structure' may be a pymatgen Structure or,
+            depending on the mp-api version, its MSONable dict form.
         determine_oxi (str): The method to determine the assignments oxidation states in the structure.
                 Options are 'BV', 'comp_ICSD','both' for determining the oxidation states by bond valence,
                 ICSD statistics or trial both sequentially, respectively.
@@ -337,7 +338,14 @@ def parse_mprest(
 
     """
     try:
-        structure = cast("pmg_Structure", data["structure"])
+        structure = data["structure"]
+        # mp-api's use_document_model=False controls the top-level document only; whether
+        # a nested "structure" field is left as a Structure or serialised to an MSONable
+        # dict (@class/@module/lattice/sites) has changed between mp-api releases, so
+        # handle both rather than assuming the field always deserialises to the same type.
+        if isinstance(structure, dict):
+            structure = pmg_Structure.from_dict(structure)
+        structure = cast("pmg_Structure", structure)
         return SmactStructure.from_py_struct(structure, determine_oxi=determine_oxi)
     except (ValueError, RuntimeError, TypeError):
         # Couldn't decorate with oxidation states

--- a/smact/tests/test_structure.py
+++ b/smact/tests/test_structure.py
@@ -664,6 +664,20 @@ def test_parse_mprest_exception_path():
     parse_mprest({"structure": "not_a_structure", "material_id": "mp-test"})
 
 
+def test_parse_mprest_dict_structure():
+    """use_document_model=False, mp-api>=0.46: nested "structure" is an MSONable dict.
+
+    Same mp-api behaviour as test_from_mp_mocked_new_api_dict_structure: the "structure"
+    field comes back as {"@class": ..., "@module": ..., "lattice": ..., "sites": ..., ...}
+    rather than a Structure object, which parse_mprest must convert via Structure.from_dict.
+    """
+    real_struct = PmgStructure.from_file(os.path.join(files_dir, "CaTiO3.json"))
+
+    result = parse_mprest({"structure": real_struct.as_dict(), "material_id": "mp-4019"})
+
+    assert isinstance(result, SmactStructure)
+
+
 # ---------------------------------------------------------------------------
 # CationMutatorTest
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `parse_mprest()` (used by `StructureDB.add_mp_icsd`) passed `data["structure"]` straight into `SmactStructure.from_py_struct()`, which raises `TypeError` unless given a pymatgen `Structure`.
- `mp-api`'s `use_document_model=False` only controls the top-level document; whether the nested `"structure"` field deserialises to a `Structure` or stays an MSONable dict has changed between `mp-api` releases (0.45.5 returns a `Structure`; 0.46.5 — what a fresh `pip install` resolves to today, since `pyproject.toml` only requires `mp-api>=0.45.3` — returns a dict).
- With a dict, every structure failed with `"Couldn't decorate ... with oxidation states"` and `add_mp_icsd` silently returned `0`, which is exactly the symptom reported in #664 when running `docs/tutorials/structure_prediction.ipynb`.
- This is the same class of bug already fixed for `SmactStructure.from_mp()` in 90c194be, but that fix missed this sibling call path in `database.py`. This PR mirrors it there.

Fixes #664

## Test plan
- [x] Added `test_parse_mprest_dict_structure`, which reproduces the exact warning from #664 on the old code and passes with the fix.
- [x] Verified against a fresh install that resolves `mp-api==0.46.5` (matching the reporter's environment).
- [x] `pytest smact/tests/test_structure.py` — 69 passed, 1 skipped (live MP API test, no key available).
- [x] `ruff check` / `ruff format --check` on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structure parsing for Materials Project API responses that provide serialised structure data.
  * Ensured these responses are converted correctly and returned as valid SMACT structures.

* **Tests**
  * Added coverage for parsing serialised structure data from newer API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->